### PR TITLE
feat(dashboard): allow closing CLI sessions from the dashboard

### DIFF
--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -1,5 +1,6 @@
 import {
   DASHBOARD_MAX_LABEL_LENGTH,
+  type DashboardCloseAgentArgs,
   type DashboardRevealAgentArgs,
   type DashboardSnapshot
 } from '../../shared/dashboard-snapshot'
@@ -71,6 +72,17 @@ export function isDashboardRevealAgentArgs(value: unknown): value is DashboardRe
 
 export function isDashboardPaneKey(value: unknown): value is string {
   return isBoundedString(value, MAX_ID_LENGTH)
+}
+
+export function isDashboardCloseAgentArgs(value: unknown): value is DashboardCloseAgentArgs {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const args = value as Record<string, unknown>
+  return (
+    isDashboardPaneKey(args.paneKey) &&
+    (args.tabId === null || isBoundedString(args.tabId, MAX_ID_LENGTH))
+  )
 }
 
 export function isDashboardSnapshot(value: unknown): value is DashboardSnapshot {

--- a/src/main/ipc/dashboard-popout.test.ts
+++ b/src/main/ipc/dashboard-popout.test.ts
@@ -240,6 +240,40 @@ describe('registerDashboardPopoutHandlers', () => {
     expect(sendToTrustedMock).toHaveBeenCalledWith('ui:ackDashboardAgent', 'tab1:leaf1')
   })
 
+  it('relays valid session-close requests from only the popout', () => {
+    handlers.get('dashboardPopout:closeAgent')!({ sender: untrustedSender } as never, {
+      paneKey: 'tab1:leaf1',
+      tabId: 'tab1'
+    })
+    handlers.get('dashboardPopout:closeAgent')!({ sender: popoutSender } as never, {
+      paneKey: '',
+      tabId: 'tab1'
+    })
+    handlers.get('dashboardPopout:closeAgent')!({ sender: popoutSender } as never, {
+      paneKey: 'tab1:leaf1',
+      tabId: 42
+    })
+    expect(sendToTrustedMock).not.toHaveBeenCalled()
+
+    handlers.get('dashboardPopout:closeAgent')!({ sender: popoutSender } as never, {
+      paneKey: 'tab1:leaf1',
+      tabId: 'tab1'
+    })
+    expect(sendToTrustedMock).toHaveBeenCalledWith('ui:closeDashboardAgent', {
+      paneKey: 'tab1:leaf1',
+      tabId: 'tab1'
+    })
+
+    handlers.get('dashboardPopout:closeAgent')!({ sender: popoutSender } as never, {
+      paneKey: 'tab2:leaf2',
+      tabId: null
+    })
+    expect(sendToTrustedMock).toHaveBeenCalledWith('ui:closeDashboardAgent', {
+      paneKey: 'tab2:leaf2',
+      tabId: null
+    })
+  })
+
   it('reveals an agent in only the trusted main window', () => {
     const main = makeWindow(mainSender)
     getTrustedWindowMock.mockReturnValue(main)

--- a/src/main/ipc/dashboard-popout.ts
+++ b/src/main/ipc/dashboard-popout.ts
@@ -13,6 +13,7 @@ import { safelyRevealWindow } from '../window/focus-existing-window'
 import { getTrustedUIRendererWindow, isTrustedUIRenderer, sendToTrustedUIRenderer } from './ui'
 import {
   admitDashboardSnapshot,
+  isDashboardCloseAgentArgs,
   isDashboardPaneKey,
   isDashboardRevealAgentArgs
 } from './dashboard-payload-validation'
@@ -36,6 +37,7 @@ export function registerDashboardPopoutHandlers(
   ipcMain.removeHandler('dashboard:getPopoutOpen')
   ipcMain.removeHandler('dashboardPopout:revealAgent')
   ipcMain.removeHandler('dashboardPopout:ackAgent')
+  ipcMain.removeHandler('dashboardPopout:closeAgent')
 
   onDashboardPopoutOpenChanged((open) => {
     if (!open) {
@@ -118,6 +120,19 @@ export function registerDashboardPopoutHandlers(
       return
     }
     sendToTrustedUIRenderer('ui:ackDashboardAgent', (args as { paneKey: string }).paneKey)
+  })
+
+  // Session close: the popout owns no PTYs, so the main renderer runs the
+  // canonical closeTerminalTab (or dismisses the row when the tab is gone).
+  ipcMain.handle('dashboardPopout:closeAgent', (event, args: unknown): void => {
+    if (
+      !isDashboardPopoutRenderer(event.sender) ||
+      !isDashboardEnabled(store) ||
+      !isDashboardCloseAgentArgs(args)
+    ) {
+      return
+    }
+    sendToTrustedUIRenderer('ui:closeDashboardAgent', args)
   })
 
   // Click-to-focus: raise the main window and route it to the agent's pane.

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -10,7 +10,11 @@ import type {
 } from '../shared/hosted-review'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
 import type { BrowserFindSource } from '../shared/browser-find-source'
-import type { DashboardSnapshot, DashboardRevealAgentArgs } from '../shared/dashboard-snapshot'
+import type {
+  DashboardSnapshot,
+  DashboardRevealAgentArgs,
+  DashboardCloseAgentArgs
+} from '../shared/dashboard-snapshot'
 import type {
   TerminalPreviewConnectResult,
   TerminalPreviewDataPayload
@@ -2467,10 +2471,12 @@ export type PreloadApi = {
     onSnapshotRequested: (callback: () => void) => () => void
     onRevealAgent: (callback: (args: DashboardRevealAgentArgs) => void) => () => void
     onAckAgent: (callback: (paneKey: string) => void) => () => void
+    onCloseAgent: (callback: (args: DashboardCloseAgentArgs) => void) => () => void
     requestSnapshot: () => Promise<void>
     onSnapshot: (callback: (snapshot: DashboardSnapshot) => void) => () => void
     revealAgent: (args: DashboardRevealAgentArgs) => Promise<void>
     ackAgent: (paneKey: string) => Promise<void>
+    closeAgent: (args: DashboardCloseAgentArgs) => Promise<void>
   }
   terminalPreview: {
     connect: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,7 +4,11 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
-import type { DashboardSnapshot, DashboardRevealAgentArgs } from '../shared/dashboard-snapshot'
+import type {
+  DashboardSnapshot,
+  DashboardRevealAgentArgs,
+  DashboardCloseAgentArgs
+} from '../shared/dashboard-snapshot'
 import type {
   TerminalPreviewConnectResult,
   TerminalPreviewDataPayload
@@ -2291,6 +2295,12 @@ const api = {
       ipcRenderer.on('ui:ackDashboardAgent', listener)
       return () => ipcRenderer.removeListener('ui:ackDashboardAgent', listener)
     },
+    onCloseAgent: (callback: (args: DashboardCloseAgentArgs) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, args: DashboardCloseAgentArgs): void =>
+        callback(args)
+      ipcRenderer.on('ui:closeDashboardAgent', listener)
+      return () => ipcRenderer.removeListener('ui:closeDashboardAgent', listener)
+    },
 
     // ── Consumer side (pop-out window) ───────────────────────────────────
     requestSnapshot: (): Promise<void> => ipcRenderer.invoke('dashboard:requestSnapshot'),
@@ -2303,7 +2313,9 @@ const api = {
     revealAgent: (args: DashboardRevealAgentArgs): Promise<void> =>
       ipcRenderer.invoke('dashboardPopout:revealAgent', args),
     ackAgent: (paneKey: string): Promise<void> =>
-      ipcRenderer.invoke('dashboardPopout:ackAgent', { paneKey })
+      ipcRenderer.invoke('dashboardPopout:ackAgent', { paneKey }),
+    closeAgent: (args: DashboardCloseAgentArgs): Promise<void> =>
+      ipcRenderer.invoke('dashboardPopout:closeAgent', args)
   },
 
   terminalPreview: {

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.tsx
@@ -10,6 +10,15 @@ import type { RepoIcon } from '../../../../shared/repo-icon'
 import { cn } from '@/lib/utils'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 import { AgentKanbanCard } from './AgentKanbanCard'
 import { AgentDashboardToolbar } from './AgentDashboardToolbar'
 import { AgentTerminalDialog, type AgentRevealArgs } from './AgentTerminalDialog'
@@ -71,13 +80,15 @@ function KanbanColumn({
   cards,
   repoIconsByRepoId,
   now,
-  onOpenTerminal
+  onOpenTerminal,
+  onClose
 }: {
   bucket: DashboardBucket
   cards: DashboardCard[]
   repoIconsByRepoId: Record<string, RepoIcon | null> | undefined
   now: number
   onOpenTerminal: (card: DashboardCard) => void
+  onClose: (card: DashboardCard) => void
 }): React.JSX.Element {
   return (
     // Why: attention no longer tints the whole column — the cards inside carry
@@ -104,6 +115,7 @@ function KanbanColumn({
               repoIcon={repoIconsByRepoId?.[card.repoId] ?? null}
               now={now}
               onOpenTerminal={onOpenTerminal}
+              onClose={onClose}
             />
           ))
         )}
@@ -216,6 +228,27 @@ export function AgentKanbanBoard({
     }
   }, [dialogCard?.unseen, dialogCard?.paneKey, onAckAgent])
 
+  // Session close: live sessions confirm first (the whole terminal tab dies,
+  // splits included); a card without a live PTY is dead state — dismiss it
+  // straight away. The actual close runs in the main renderer via the relay.
+  const [closeTarget, setCloseTarget] = useState<DashboardCard | null>(null)
+  const handleCloseCard = useCallback((card: DashboardCard) => {
+    if (card.ptyId === null) {
+      void window.api.dashboard.closeAgent?.({ paneKey: card.paneKey, tabId: card.tabId })
+      return
+    }
+    setCloseTarget(card)
+  }, [])
+  const handleConfirmClose = useCallback(() => {
+    if (closeTarget) {
+      void window.api.dashboard.closeAgent?.({
+        paneKey: closeTarget.paneKey,
+        tabId: closeTarget.tabId
+      })
+    }
+    setCloseTarget(null)
+  }, [closeTarget])
+
   return (
     // Why: the pop-out is its own React root with no app-level provider, and the
     // card's repo tooltip needs one in both hosts. Nesting inside the main
@@ -267,6 +300,7 @@ export function AgentKanbanBoard({
                 repoIconsByRepoId={snapshot.repoIconsByRepoId}
                 now={now}
                 onOpenTerminal={handleOpenTerminal}
+                onClose={handleCloseCard}
               />
             ))}
           </div>
@@ -276,6 +310,38 @@ export function AgentKanbanBoard({
           onOpenChange={handleDialogOpenChange}
           onReveal={onRevealAgent}
         />
+        <Dialog
+          open={closeTarget !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setCloseTarget(null)
+            }
+          }}
+        >
+          {closeTarget ? (
+            <DialogContent className="max-w-sm sm:max-w-sm" showCloseButton={false}>
+              <DialogHeader>
+                <DialogTitle className="text-sm">
+                  {translate('dashboardPopout.card.closeTitle', 'Close agent session?')}
+                </DialogTitle>
+                <DialogDescription className="text-xs">
+                  {translate(
+                    'dashboardPopout.card.closeDescription',
+                    'This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.'
+                  )}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setCloseTarget(null)}>
+                  {translate('dashboardPopout.card.closeCancel', 'Cancel')}
+                </Button>
+                <Button variant="destructive" onClick={handleConfirmClose}>
+                  {translate('dashboardPopout.card.closeConfirm', 'Close session')}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          ) : null}
+        </Dialog>
       </div>
     </TooltipProvider>
   )

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -49,6 +49,7 @@ function renderCard(props: {
   now: number
   repoIcon?: RepoIcon | null
   onOpenTerminal?: () => void
+  onClose?: (card: DashboardCard) => void
 }): ReturnType<typeof render> {
   return render(
     <TooltipProvider>
@@ -57,6 +58,7 @@ function renderCard(props: {
         repoIcon={props.repoIcon}
         now={props.now}
         onOpenTerminal={props.onOpenTerminal ?? vi.fn()}
+        onClose={props.onClose ?? vi.fn()}
       />
     </TooltipProvider>
   )
@@ -78,6 +80,22 @@ describe('AgentKanbanCard', () => {
     expect(screen.queryByText(/\d+d/)).not.toBeInTheDocument()
   })
 
+  it('closes the session from the trailing control without opening the terminal', () => {
+    const onOpenTerminal = vi.fn()
+    const onClose = vi.fn()
+    const target = card()
+    renderCard({
+      card: target,
+      now: 2_000,
+      onOpenTerminal,
+      onClose
+    })
+
+    screen.getByRole('button', { name: 'Close session' }).click()
+    expect(onClose).toHaveBeenCalledWith(target)
+    expect(onOpenTerminal).not.toHaveBeenCalled()
+  })
+
   it('shows the question glyph once when a summary is available', () => {
     const attentionCard = card({
       bucket: 'attention',
@@ -95,6 +113,7 @@ describe('AgentKanbanCard', () => {
           card={{ ...attentionCard, askSummary: undefined }}
           now={2_000}
           onOpenTerminal={vi.fn()}
+          onClose={vi.fn()}
         />
       </TooltipProvider>
     )
@@ -222,6 +241,7 @@ describe('AgentKanbanCard', () => {
 
   it('skips structured-clone rerenders until visible card data or its age changes', () => {
     const onOpenTerminal = vi.fn()
+    const onClose = vi.fn()
     const initial = card({
       startedAt: 1_000,
       subagents: [{ id: 'child-1', name: 'Review loop', dotState: 'working' }]
@@ -234,6 +254,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={repoIcon}
           now={61_500}
           onOpenTerminal={onOpenTerminal}
+          onClose={onClose}
         />
       </TooltipProvider>
     )
@@ -248,6 +269,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ ...repoIcon }}
           now={62_000}
           onOpenTerminal={onOpenTerminal}
+          onClose={onClose}
         />
       </TooltipProvider>
     )
@@ -260,6 +282,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ ...repoIcon }}
           now={121_500}
           onOpenTerminal={onOpenTerminal}
+          onClose={onClose}
         />
       </TooltipProvider>
     )
@@ -269,6 +292,7 @@ describe('AgentKanbanCard', () => {
 
   it('rerenders when the repo icon changes', () => {
     const onOpenTerminal = vi.fn()
+    const onClose = vi.fn()
     const initial = card({ startedAt: 1_000 })
     const { rerender } = render(
       <TooltipProvider>
@@ -277,6 +301,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ type: 'lucide', name: 'Rocket' }}
           now={61_500}
           onOpenTerminal={onOpenTerminal}
+          onClose={onClose}
         />
       </TooltipProvider>
     )
@@ -289,6 +314,7 @@ describe('AgentKanbanCard', () => {
           repoIcon={{ type: 'lucide', name: 'Database' }}
           now={61_500}
           onOpenTerminal={onOpenTerminal}
+          onClose={onClose}
         />
       </TooltipProvider>
     )

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -6,7 +6,8 @@ import {
   GitPullRequest,
   GitPullRequestClosed,
   GitPullRequestDraft,
-  MessageCircleQuestion
+  MessageCircleQuestion,
+  X
 } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
@@ -184,6 +185,9 @@ type AgentKanbanCardProps = {
    *  card: bucket moves remount the card, and an embedded dialog would close
    *  the chat mid-conversation. */
   onOpenTerminal: (card: DashboardCard) => void
+  /** Asks the board to close this agent's session (it owns the confirm dialog
+   *  for the same remount reason as onOpenTerminal). */
+  onClose: (card: DashboardCard) => void
 }
 
 /** One agent on the kanban board. Clicking opens the board's live terminal dialog. */
@@ -192,7 +196,8 @@ export const AgentKanbanCard = memo(
     card,
     repoIcon = null,
     now,
-    onOpenTerminal
+    onOpenTerminal,
+    onClose
   }: AgentKanbanCardProps): React.JSX.Element {
     useTranslation()
     const [subagentsOpen, setSubagentsOpen] = useState(false)
@@ -206,6 +211,22 @@ export const AgentKanbanCard = memo(
     // twice.
     const heading = card.conversationName ?? card.worktreeName
     const worktreeInFooter = card.conversationName !== undefined
+
+    // Why: the card root is a <button>, so the close control is a role=button
+    // span (nested <button> is invalid HTML); it must not trigger the card's
+    // own click activation.
+    const handleCloseClick = (event: React.MouseEvent): void => {
+      event.preventDefault()
+      event.stopPropagation()
+      onClose(card)
+    }
+    const handleCloseKeyDown = (event: React.KeyboardEvent): void => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        event.stopPropagation()
+        onClose(card)
+      }
+    }
 
     return (
       <div
@@ -240,7 +261,34 @@ export const AgentKanbanCard = memo(
             >
               {heading}
             </span>
-            {card.askSummary ? null : <AgentStateDot state={card.dotState} className="ml-auto" />}
+            {/* Why: state dot and close control share one slot (same pattern as
+                the sidebar's timestamp/dismiss-X); the dot yields on hover and on
+                touch devices, where the X is always visible. */}
+            <span className="relative ml-auto grid shrink-0 grid-cols-1 grid-rows-1 items-center justify-items-end">
+              {card.askSummary ? null : (
+                <AgentStateDot
+                  state={card.dotState}
+                  // Why: pointer-events-none — a sub-1 opacity element stacks above
+                  // the close span and would eat its clicks even when invisible.
+                  className="pointer-events-none [grid-area:1/1] transition-opacity duration-150 group-hover:opacity-0 [@media(hover:none)]:opacity-0"
+                />
+              )}
+              <span
+                role="button"
+                tabIndex={0}
+                aria-label={translate('dashboardPopout.card.closeSession', 'Close session')}
+                title={translate('dashboardPopout.card.closeSession', 'Close session')}
+                onClick={handleCloseClick}
+                onKeyDown={handleCloseKeyDown}
+                className={cn(
+                  '[grid-area:1/1] inline-flex items-center justify-center text-muted-foreground/70 hover:text-foreground',
+                  'can-hover:opacity-0 transition-opacity duration-150',
+                  'group-hover:opacity-100 focus-visible:opacity-100'
+                )}
+              >
+                <X className="size-3.5" />
+              </span>
+            </span>
           </div>
 
           {card.lastUserMessage || card.lastAgentMessage ? (
@@ -336,6 +384,7 @@ export const AgentKanbanCard = memo(
   },
   (previous, next) =>
     previous.onOpenTerminal === next.onOpenTerminal &&
+    previous.onClose === next.onClose &&
     sameCard(previous.card, next.card) &&
     sameRepoIcon(previous.repoIcon, next.repoIcon) &&
     (displayTimestamp(previous.card) <= 0 ||

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -71,6 +71,8 @@ function stateDotTooltipLabel(agent: DashboardAgentRowData, dotState: AgentDotSt
 type Props = {
   agent: DashboardAgentRowData
   onDismiss: (paneKey: string) => void
+  /** Closes the agent's whole terminal tab (splits included); live rows only. */
+  onCloseSession?: (paneKey: string) => void
   /** Navigate to this agent's tab; paneKey lets the caller mark-visit the exact clicked row. */
   onActivate: (tabId: string, paneKey: string) => void
   /** Why: injected from a parent so one shared tick re-renders every row's "Xm ago" (see useNow.ts), not a per-row interval. */
@@ -101,6 +103,7 @@ type Props = {
 const DashboardAgentRow = React.memo(function DashboardAgentRow({
   agent,
   onDismiss,
+  onCloseSession,
   onActivate,
   now,
   isUnvisited = false,
@@ -311,6 +314,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
           hideDismiss={agent.rowSource === 'subagent'}
           sendTargetStatus={sendTargetStatus}
           onDismiss={onDismiss}
+          onCloseSession={onCloseSession}
           onToggleExpanded={handleToggleExpanded}
           onSendTargetClick={onSendTargetClick}
         />

--- a/src/renderer/src/components/dashboard/DashboardAgentRowTrailingControls.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRowTrailingControls.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { ChevronDown, Send, X } from 'lucide-react'
+import { ChevronDown, Send, Square, X } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 
@@ -13,6 +13,9 @@ type DashboardAgentRowTrailingControlsProps = {
   hideDismiss?: boolean
   sendTargetStatus?: 'eligible' | 'disabled' | 'sending'
   onDismiss: (paneKey: string) => void
+  /** Closes the agent's whole terminal tab (splits included) after confirmation.
+   *  Offered only for live rows — retained/dead rows get the dismiss X alone. */
+  onCloseSession?: (paneKey: string) => void
   onToggleExpanded: () => void
   onSendTargetClick?: (paneKey: string) => void
 }
@@ -25,6 +28,7 @@ export function DashboardAgentRowTrailingControls({
   hideDismiss = false,
   sendTargetStatus,
   onDismiss,
+  onCloseSession,
   onToggleExpanded,
   onSendTargetClick
 }: DashboardAgentRowTrailingControlsProps): React.JSX.Element {
@@ -45,6 +49,14 @@ export function DashboardAgentRowTrailingControls({
     },
     [onDismiss, paneKey]
   )
+  const handleCloseSession = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault()
+      event.stopPropagation()
+      onCloseSession?.(paneKey)
+    },
+    [onCloseSession, paneKey]
+  )
   const handleToggleExpand = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault()
@@ -63,6 +75,33 @@ export function DashboardAgentRowTrailingControls({
     },
     [onSendTargetClick, paneKey, sendTargetStatus]
   )
+
+  // Why: timestamp/dismiss hover reveal lives on each button (not a wrapper)
+  // so keyboard focus reveals the focused control itself.
+  const hoverRevealClasses =
+    'can-hover:opacity-0 transition-opacity duration-150 group-hover/agent-row:opacity-100 focus-visible:opacity-100'
+
+  // Why: Square reads as "stop the session" — deliberately distinct from the
+  // dismiss X, which only hides the row.
+  const closeSessionButton = onCloseSession ? (
+    <button
+      type="button"
+      onClick={handleCloseSession}
+      onMouseDown={stopMouseDown}
+      onKeyDown={stopKeyDown}
+      className={cn(
+        'inline-flex items-center justify-center text-muted-foreground/70 hover:text-foreground',
+        hoverRevealClasses
+      )}
+      aria-label={translate(
+        'auto.components.dashboard.DashboardAgentRow.271b256627',
+        'Close agent session'
+      )}
+      title={translate('auto.components.dashboard.DashboardAgentRow.1c27be5226', 'Close session')}
+    >
+      <Square className="size-3" />
+    </button>
+  ) : null
 
   return (
     <span className="relative ml-auto flex h-3.5 w-12 shrink-0 items-center justify-end">
@@ -112,15 +151,39 @@ export function DashboardAgentRowTrailingControls({
           >
             {relativeTimestamp}
           </span>
+          <span className="[grid-area:1/1] inline-flex items-center justify-end gap-1">
+            {closeSessionButton}
+            <button
+              type="button"
+              onClick={handleDismiss}
+              onMouseDown={stopMouseDown}
+              onKeyDown={stopKeyDown}
+              className={cn(
+                'inline-flex items-center justify-center text-muted-foreground/70 hover:text-foreground',
+                hoverRevealClasses
+              )}
+              aria-label={translate(
+                'auto.components.dashboard.DashboardAgentRow.b06e13fcf7',
+                'Dismiss agent'
+              )}
+              title={translate('auto.components.dashboard.DashboardAgentRow.5ae84475cc', 'Dismiss')}
+            >
+              <X className="size-3.5" />
+            </button>
+          </span>
+        </span>
+      )}
+      {!sendTargetStatus && !hideDismiss && relativeTimestamp === null && (
+        <span className="inline-flex shrink-0 items-center justify-end gap-1">
+          {closeSessionButton}
           <button
             type="button"
             onClick={handleDismiss}
             onMouseDown={stopMouseDown}
             onKeyDown={stopKeyDown}
             className={cn(
-              '[grid-area:1/1] inline-flex items-center justify-center text-muted-foreground/70 hover:text-foreground',
-              'can-hover:opacity-0 transition-opacity duration-150',
-              'group-hover/agent-row:opacity-100 focus-visible:opacity-100'
+              'inline-flex items-center justify-center text-muted-foreground/70 hover:text-foreground',
+              hoverRevealClasses
             )}
             aria-label={translate(
               'auto.components.dashboard.DashboardAgentRow.b06e13fcf7',
@@ -131,26 +194,6 @@ export function DashboardAgentRowTrailingControls({
             <X className="size-3.5" />
           </button>
         </span>
-      )}
-      {!sendTargetStatus && !hideDismiss && relativeTimestamp === null && (
-        <button
-          type="button"
-          onClick={handleDismiss}
-          onMouseDown={stopMouseDown}
-          onKeyDown={stopKeyDown}
-          className={cn(
-            'inline-flex shrink-0 items-center justify-center text-muted-foreground/70 hover:text-foreground',
-            'can-hover:opacity-0 transition-opacity duration-150',
-            'group-hover/agent-row:opacity-100 focus-visible:opacity-100'
-          )}
-          aria-label={translate(
-            'auto.components.dashboard.DashboardAgentRow.b06e13fcf7',
-            'Dismiss agent'
-          )}
-          title={translate('auto.components.dashboard.DashboardAgentRow.5ae84475cc', 'Dismiss')}
-        >
-          <X className="size-3.5" />
-        </button>
       )}
       {!hideExpand && (
         <button

--- a/src/renderer/src/components/dashboard/close-dashboard-agent-session.ts
+++ b/src/renderer/src/components/dashboard/close-dashboard-agent-session.ts
@@ -1,0 +1,21 @@
+import { useAppStore } from '@/store'
+import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
+import { resolveTerminalCloseTarget } from '@/components/terminal/terminal-close-target'
+import type { DashboardCloseAgentArgs } from '../../../../shared/dashboard-snapshot'
+
+/**
+ * Close a CLI agent session from a dashboard surface (sidebar row or, relayed
+ * over IPC, the pop-out board). Closing kills the WHOLE terminal tab — split
+ * panes and any sibling agents included — via the canonical closeTerminalTab
+ * (PTY kill, host routing, pinned guard). When the tab is already gone the row
+ * is dead state, so it is just dismissed.
+ */
+export function closeDashboardAgentSession(args: DashboardCloseAgentArgs): void {
+  const state = useAppStore.getState()
+  if (args.tabId !== null && resolveTerminalCloseTarget(state, args.tabId, undefined)) {
+    closeTerminalTab(args.tabId, { reason: 'user' })
+    return
+  }
+  state.dropAgentStatus(args.paneKey)
+  state.dismissRetainedAgent(args.paneKey)
+}

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
@@ -7,9 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   acknowledgeAgents: vi.fn(),
   setActiveWorktree: vi.fn(),
+  dropAgentStatus: vi.fn(),
+  dismissRetainedAgent: vi.fn(),
+  closeTerminalTab: vi.fn(),
   subscribeStore: vi.fn((_listener: (state: unknown, previousState: unknown) => void) => vi.fn()),
   onRevealAgent: vi.fn(),
   onAckAgent: vi.fn(),
+  onCloseAgent: vi.fn(),
   onPopoutOpenChanged: vi.fn(),
   onSnapshotRequested: vi.fn(),
   getPopoutOpen: vi.fn(async () => false),
@@ -19,18 +23,31 @@ const mocks = vi.hoisted(() => ({
   ),
   offRevealAgent: vi.fn(),
   offAckAgent: vi.fn(),
+  offCloseAgent: vi.fn(),
   offPopoutOpenChanged: vi.fn(),
-  offSnapshotRequested: vi.fn()
+  offSnapshotRequested: vi.fn(),
+  storeState: {
+    tabsByWorktree: {} as Record<string, { id: string }[]>,
+    unifiedTabsByWorktree: {} as Record<string, unknown[]>
+  }
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => ({
       acknowledgeAgents: mocks.acknowledgeAgents,
-      setActiveWorktree: mocks.setActiveWorktree
+      setActiveWorktree: mocks.setActiveWorktree,
+      dropAgentStatus: mocks.dropAgentStatus,
+      dismissRetainedAgent: mocks.dismissRetainedAgent,
+      tabsByWorktree: mocks.storeState.tabsByWorktree,
+      unifiedTabsByWorktree: mocks.storeState.unifiedTabsByWorktree
     }),
     subscribe: mocks.subscribeStore
   }
+}))
+
+vi.mock('@/components/terminal/terminal-tab-actions', () => ({
+  closeTerminalTab: mocks.closeTerminalTab
 }))
 
 vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
@@ -92,12 +109,14 @@ function Harness({ enabled }: { enabled: boolean }): null {
 function installDashboardApi(): void {
   mocks.onRevealAgent.mockReturnValue(mocks.offRevealAgent)
   mocks.onAckAgent.mockReturnValue(mocks.offAckAgent)
+  mocks.onCloseAgent.mockReturnValue(mocks.offCloseAgent)
   mocks.onPopoutOpenChanged.mockReturnValue(mocks.offPopoutOpenChanged)
   mocks.onSnapshotRequested.mockReturnValue(mocks.offSnapshotRequested)
   ;(window as unknown as { api: unknown }).api = {
     dashboard: {
       onRevealAgent: mocks.onRevealAgent,
       onAckAgent: mocks.onAckAgent,
+      onCloseAgent: mocks.onCloseAgent,
       onPopoutOpenChanged: mocks.onPopoutOpenChanged,
       onSnapshotRequested: mocks.onSnapshotRequested,
       getPopoutOpen: mocks.getPopoutOpen,
@@ -113,6 +132,8 @@ describe('useDashboardPopoutBridge', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     installDashboardApi()
+    mocks.storeState.tabsByWorktree = {}
+    mocks.storeState.unifiedTabsByWorktree = {}
     container = document.createElement('div')
     root = createRoot(container)
   })
@@ -126,6 +147,7 @@ describe('useDashboardPopoutBridge', () => {
 
     expect(mocks.onRevealAgent).not.toHaveBeenCalled()
     expect(mocks.onAckAgent).not.toHaveBeenCalled()
+    expect(mocks.onCloseAgent).not.toHaveBeenCalled()
     expect(mocks.onPopoutOpenChanged).not.toHaveBeenCalled()
     expect(mocks.onSnapshotRequested).not.toHaveBeenCalled()
     expect(mocks.getPopoutOpen).not.toHaveBeenCalled()
@@ -211,6 +233,7 @@ describe('useDashboardPopoutBridge', () => {
 
     expect(mocks.onRevealAgent).toHaveBeenCalledTimes(1)
     expect(mocks.onAckAgent).toHaveBeenCalledTimes(1)
+    expect(mocks.onCloseAgent).toHaveBeenCalledTimes(1)
     expect(mocks.onPopoutOpenChanged).toHaveBeenCalledTimes(1)
     expect(mocks.onSnapshotRequested).toHaveBeenCalledTimes(1)
     expect(mocks.getPopoutOpen).toHaveBeenCalledTimes(1)
@@ -219,8 +242,33 @@ describe('useDashboardPopoutBridge', () => {
 
     expect(mocks.offRevealAgent).toHaveBeenCalledTimes(1)
     expect(mocks.offAckAgent).toHaveBeenCalledTimes(1)
+    expect(mocks.offCloseAgent).toHaveBeenCalledTimes(1)
     expect(mocks.offPopoutOpenChanged).toHaveBeenCalledTimes(1)
     expect(mocks.offSnapshotRequested).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the whole tab for a live session and only dismisses a dead row', async () => {
+    await act(async () => root.render(<Harness enabled />))
+    const closeHandler = mocks.onCloseAgent.mock.calls[0][0] as (args: {
+      paneKey: string
+      tabId: string | null
+    }) => void
+
+    mocks.storeState.tabsByWorktree = { 'wt-1': [{ id: 'tab-1' }] }
+    closeHandler({ paneKey: 'tab-1:leaf-1', tabId: 'tab-1' })
+    expect(mocks.closeTerminalTab).toHaveBeenCalledWith('tab-1', { reason: 'user' })
+    expect(mocks.dropAgentStatus).not.toHaveBeenCalled()
+    expect(mocks.dismissRetainedAgent).not.toHaveBeenCalled()
+
+    // The tab is already gone: nothing to kill, so the row is just dismissed.
+    mocks.storeState.tabsByWorktree = {}
+    closeHandler({ paneKey: 'tab-2:leaf-2', tabId: 'tab-2' })
+    closeHandler({ paneKey: 'tab-3:leaf-3', tabId: null })
+    expect(mocks.closeTerminalTab).toHaveBeenCalledTimes(1)
+    expect(mocks.dropAgentStatus).toHaveBeenCalledWith('tab-2:leaf-2')
+    expect(mocks.dismissRetainedAgent).toHaveBeenCalledWith('tab-2:leaf-2')
+    expect(mocks.dropAgentStatus).toHaveBeenCalledWith('tab-3:leaf-3')
+    expect(mocks.dismissRetainedAgent).toHaveBeenCalledWith('tab-3:leaf-3')
   })
 })
 

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
@@ -3,6 +3,7 @@ import { useAppStore, type AppState } from '@/store'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
+import { closeDashboardAgentSession } from './close-dashboard-agent-session'
 
 // Why: cap snapshot rebuilds during bursts of agent-status pings. The board is a
 // glanceable surface, so ~4 updates/sec is plenty and keeps the cross-worktree
@@ -123,6 +124,17 @@ export function useDashboardPopoutBridge(enabled: boolean): void {
     }
     return window.api.dashboard.onAckAgent?.((paneKey) => {
       useAppStore.getState().acknowledgeAgents([paneKey])
+    })
+  }, [enabled])
+
+  // Session-close requests from the popout: close the whole terminal tab (or
+  // dismiss the dead row) in this window, which owns the PTYs.
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    return window.api.dashboard.onCloseAgent?.((args) => {
+      closeDashboardAgentSession(args)
     })
   }, [enabled])
 

--- a/src/renderer/src/components/sidebar/CloseAgentSessionDialog.tsx
+++ b/src/renderer/src/components/sidebar/CloseAgentSessionDialog.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+
+type Props = {
+  open: boolean
+  onConfirm: () => void
+  onOpenChange: (open: boolean) => void
+}
+
+/** Confirms closing an agent session: the WHOLE terminal tab dies, split panes
+ *  and any sibling agents included. */
+export const CloseAgentSessionDialog = React.memo(function CloseAgentSessionDialog({
+  open,
+  onConfirm,
+  onOpenChange
+}: Props): React.JSX.Element {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <DialogContent className="max-w-sm sm:max-w-sm" showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              {translate(
+                'auto.components.sidebar.WorktreeCardAgents.2ec931a922',
+                'Close agent session?'
+              )}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              {translate(
+                'auto.components.sidebar.WorktreeCardAgents.e1250e23e9',
+                'This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              {translate('auto.components.sidebar.WorktreeCardAgents.7d17689ff0', 'Cancel')}
+            </Button>
+            <Button variant="destructive" onClick={onConfirm}>
+              {translate('auto.components.sidebar.WorktreeCardAgents.6ac88e0ff9', 'Close session')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  )
+})

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -5,6 +5,8 @@ import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import DashboardAgentRow from '@/components/dashboard/DashboardAgentRow'
 import { useNow } from '@/components/dashboard/useNow'
+import { CloseAgentSessionDialog } from './CloseAgentSessionDialog'
+import { useAgentSessionClose } from './use-agent-session-close'
 import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
 import {
   selectSendTargetControlInputs,
@@ -107,6 +109,9 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     },
     [dropAgentStatus, dismissRetainedAgent]
   )
+
+  // Retained rows have nothing to kill, so they keep only the dismiss X.
+  const { closeTarget, requestClose, confirmClose, cancelClose } = useAgentSessionClose(agents)
 
   const isAgentSendTargetModeActive = agentSendPopoverTargetMode !== null
   const sendTargetsByPaneKey = useMemo(() => {
@@ -261,6 +266,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
         <DashboardAgentRow
           agent={agent}
           onDismiss={handleDismissAgent}
+          onCloseSession={agent.rowSource === 'retained' ? undefined : requestClose}
           onActivate={
             agent.rowSource === 'retained' ? handleActivateRetainedAgent : handleActivateAgentTab
           }
@@ -414,6 +420,15 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
       aria-label={translate('auto.components.sidebar.WorktreeCardAgents.1b0a156717', 'Agents')}
     >
       {rootAgents.map((rootAgent) => renderAgentBranch(rootAgent))}
+      <CloseAgentSessionDialog
+        open={closeTarget !== null}
+        onConfirm={confirmClose}
+        onOpenChange={(open) => {
+          if (!open) {
+            cancelClose()
+          }
+        }}
+      />
     </div>
   )
 })

--- a/src/renderer/src/components/sidebar/use-agent-session-close.ts
+++ b/src/renderer/src/components/sidebar/use-agent-session-close.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react'
+import { parsePaneKey, parseLegacyNumericPaneKey } from '../../../../shared/stable-pane-id'
+import { closeDashboardAgentSession } from '@/components/dashboard/close-dashboard-agent-session'
+import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+
+/**
+ * Confirmation state for closing an agent session from the sidebar. Live rows
+ * confirm first — the whole terminal tab dies, splits and sibling agents
+ * included. Retained rows have nothing to kill, so they never reach this.
+ */
+export function useAgentSessionClose(agents: DashboardAgentRowData[]): {
+  closeTarget: DashboardAgentRowData | null
+  requestClose: (paneKey: string) => void
+  confirmClose: () => void
+  cancelClose: () => void
+} {
+  const [closeTarget, setCloseTarget] = useState<DashboardAgentRowData | null>(null)
+  const requestClose = useCallback(
+    (paneKey: string) => {
+      const row = agents.find((a) => a.paneKey === paneKey)
+      if (row) {
+        setCloseTarget(row)
+      }
+    },
+    [agents]
+  )
+  const confirmClose = useCallback(() => {
+    if (closeTarget) {
+      const parsed =
+        parsePaneKey(closeTarget.paneKey) ?? parseLegacyNumericPaneKey(closeTarget.paneKey)
+      closeDashboardAgentSession({
+        // Why: a malformed paneKey still resolves via the row's live tab id.
+        tabId: parsed?.tabId ?? closeTarget.tab.id,
+        paneKey: closeTarget.paneKey
+      })
+    }
+    setCloseTarget(null)
+  }, [closeTarget])
+  const cancelClose = useCallback(() => setCloseTarget(null), [])
+  return { closeTarget, requestClose, confirmClose, cancelClose }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4497,7 +4497,11 @@
           "ef18787206": "Queued for deletion"
         },
         "WorktreeCardAgents": {
-          "1b0a156717": "Agents"
+          "1b0a156717": "Agents",
+          "2ec931a922": "Close agent session?",
+          "e1250e23e9": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+          "7d17689ff0": "Cancel",
+          "6ac88e0ff9": "Close session"
         },
         "WorktreeCardReviewDetailSection": {
           "copyLink": "Copy link",
@@ -13299,7 +13303,9 @@
           "b06e13fcf7": "Dismiss agent",
           "0272969e28": "Send to this agent",
           "92a7017987": "sending",
-          "019b74d93a": "eligible"
+          "019b74d93a": "eligible",
+          "271b256627": "Close agent session",
+          "1c27be5226": "Close session"
         },
         "DashboardAgentRowMessage": {
           "0a01046763": "interrupted",
@@ -14637,7 +14643,12 @@
         "closed": "Closed review"
       },
       "subagents_one": "{{count}} subagent",
-      "subagents_other": "{{count}} subagents"
+      "subagents_other": "{{count}} subagents",
+      "closeTitle": "Close agent session?",
+      "closeDescription": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+      "closeCancel": "Cancel",
+      "closeConfirm": "Close session",
+      "closeSession": "Close session"
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4432,7 +4432,11 @@
           "ef18787206": "En cola para eliminación"
         },
         "WorktreeCardAgents": {
-          "1b0a156717": "Agents"
+          "1b0a156717": "Agents",
+          "2ec931a922": "Close agent session?",
+          "e1250e23e9": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+          "7d17689ff0": "Cancel",
+          "6ac88e0ff9": "Close session"
         },
         "WorktreeCardReviewDetailSection": {
           "reviewHeader": "{{value0}} #{{value1}}",
@@ -13198,7 +13202,9 @@
           "b06e13fcf7": "Despedir agente",
           "0272969e28": "Enviar a este agente",
           "92a7017987": "envío",
-          "019b74d93a": "elegible"
+          "019b74d93a": "elegible",
+          "271b256627": "Close agent session",
+          "1c27be5226": "Close session"
         },
         "DashboardAgentRowMessage": {
           "0a01046763": "interrumpido",
@@ -14523,7 +14529,12 @@
         "closed": "Revisión cerrada"
       },
       "subagents_one": "{{count}} subagente",
-      "subagents_other": "{{count}} subagentes"
+      "subagents_other": "{{count}} subagentes",
+      "closeTitle": "Close agent session?",
+      "closeDescription": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+      "closeCancel": "Cancel",
+      "closeConfirm": "Close session",
+      "closeSession": "Close session"
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4413,7 +4413,11 @@
           "ef18787206": "削除待ち"
         },
         "WorktreeCardAgents": {
-          "1b0a156717": "エージェント"
+          "1b0a156717": "エージェント",
+          "2ec931a922": "Close agent session?",
+          "e1250e23e9": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+          "7d17689ff0": "Cancel",
+          "6ac88e0ff9": "Close session"
         },
         "WorktreeCardReviewDetailSection": {
           "reviewHeader": "{{value0}} #{{value1}}",
@@ -13198,7 +13202,9 @@
           "b06e13fcf7": "agent を閉じる",
           "0272969e28": "この agent に送信",
           "92a7017987": "送信中",
-          "019b74d93a": "適格"
+          "019b74d93a": "適格",
+          "271b256627": "Close agent session",
+          "1c27be5226": "Close session"
         },
         "DashboardAgentRowMessage": {
           "0a01046763": "中断された",
@@ -14523,7 +14529,12 @@
         "closed": "クローズ済みのレビュー"
       },
       "subagents_one": "{{count}} 個のサブエージェント",
-      "subagents_other": "{{count}} 個のサブエージェント"
+      "subagents_other": "{{count}} 個のサブエージェント",
+      "closeTitle": "Close agent session?",
+      "closeDescription": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+      "closeCancel": "Cancel",
+      "closeConfirm": "Close session",
+      "closeSession": "Close session"
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4413,7 +4413,11 @@
           "ef18787206": "삭제 대기 중"
         },
         "WorktreeCardAgents": {
-          "1b0a156717": "에이전트"
+          "1b0a156717": "에이전트",
+          "2ec931a922": "Close agent session?",
+          "e1250e23e9": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+          "7d17689ff0": "Cancel",
+          "6ac88e0ff9": "Close session"
         },
         "WorktreeCardReviewDetailSection": {
           "reviewHeader": "{{value0}} #{{value1}}",
@@ -13198,7 +13202,9 @@
           "b06e13fcf7": "agent 닫기",
           "0272969e28": "이 agent에게 보내기",
           "92a7017987": "전송 중",
-          "019b74d93a": "전송 가능"
+          "019b74d93a": "전송 가능",
+          "271b256627": "Close agent session",
+          "1c27be5226": "Close session"
         },
         "DashboardAgentRowMessage": {
           "0a01046763": "중단됨",
@@ -14523,7 +14529,12 @@
         "closed": "닫힌 리뷰"
       },
       "subagents_one": "서브에이전트 {{count}}개",
-      "subagents_other": "서브에이전트 {{count}}개"
+      "subagents_other": "서브에이전트 {{count}}개",
+      "closeTitle": "Close agent session?",
+      "closeDescription": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+      "closeCancel": "Cancel",
+      "closeConfirm": "Close session",
+      "closeSession": "Close session"
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4413,7 +4413,11 @@
           "ef18787206": "已排队删除"
         },
         "WorktreeCardAgents": {
-          "1b0a156717": "智能体"
+          "1b0a156717": "智能体",
+          "2ec931a922": "Close agent session?",
+          "e1250e23e9": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+          "7d17689ff0": "Cancel",
+          "6ac88e0ff9": "Close session"
         },
         "WorktreeCardReviewDetailSection": {
           "reviewHeader": "{{value0}} #{{value1}}",
@@ -13198,7 +13202,9 @@
           "b06e13fcf7": "关闭智能体",
           "0272969e28": "发送给该智能体",
           "92a7017987": "发送",
-          "019b74d93a": "有资格的"
+          "019b74d93a": "有资格的",
+          "271b256627": "Close agent session",
+          "1c27be5226": "Close session"
         },
         "DashboardAgentRowMessage": {
           "0a01046763": "被打断",
@@ -14523,7 +14529,12 @@
         "closed": "已关闭的评审"
       },
       "subagents_one": "{{count}} 个子代理",
-      "subagents_other": "{{count}} 个子代理"
+      "subagents_other": "{{count}} 个子代理",
+      "closeTitle": "Close agent session?",
+      "closeDescription": "This closes the entire terminal tab running this agent, including all of its split panes. Any other agents running in those panes will be stopped too.",
+      "closeCancel": "Cancel",
+      "closeConfirm": "Close session",
+      "closeSession": "Close session"
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -151,3 +151,11 @@ export type DashboardRevealAgentArgs = {
   tabId: string
   leafId: string | null
 }
+
+/** Session-close request from a dashboard surface. tabId is the terminal tab
+ *  to close (the whole tab, splits included); null when the card's tab could
+ *  not be resolved, in which case the row is dead state and only dismissed. */
+export type DashboardCloseAgentArgs = {
+  paneKey: string
+  tabId: string | null
+}

--- a/tests/e2e/dashboard-close-agent-screenshot.spec.ts
+++ b/tests/e2e/dashboard-close-agent-screenshot.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * TEMPORARY screenshot spec for the close-agent-session feature.
+ *
+ * Captures real UI screenshots of:
+ *   01 — sidebar agent row hover revealing the Square "close session" button
+ *   02 — sidebar CloseAgentSessionDialog (cancelled, session kept alive)
+ *   03 — pop-out dashboard kanban card hover revealing the close X
+ *   04 — pop-out close-session confirm Dialog (cancelled)
+ *
+ * Run:
+ *   pnpm exec electron-vite build --mode e2e   (once)
+ *   SKIP_BUILD=1 pnpm run test:e2e tests/e2e/dashboard-close-agent-screenshot.spec.ts
+ */
+
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { emitCodexHookStatus, readHookEndpoint } from './helpers/agent-hook-endpoint'
+
+const SCREENSHOT_DIR = path.join(process.cwd(), 'out', 'close-agent-screenshots')
+
+test('close-agent-session screenshots', async ({ orcaPage, electronApp }) => {
+  mkdirSync(SCREENSHOT_DIR, { recursive: true })
+
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+
+  // Why: the close-session button only exists on DashboardAgentRow (full
+  // display mode), and the sidebar list only renders when the worktree card
+  // shows inline agents — neither is the E2E default.
+  await orcaPage.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    if (!state.worktreeCardProperties.includes('inline-agents')) {
+      state.toggleWorktreeCardProperty('inline-agents')
+    }
+    state.setAgentActivityDisplayMode('full')
+  })
+
+  // Live "working" agent row via the synthetic hook endpoint.
+  await waitForActivePanePtyId(orcaPage)
+  const endpoint = await readHookEndpoint(electronApp)
+  const { paneKey, worktreeId } = await waitForActivePaneHookDescriptor(orcaPage)
+  const prompt = `close-agent-screenshot-${Date.now()}`
+  await emitCodexHookStatus(endpoint, { paneKey, worktreeId, state: 'working', prompt })
+
+  const agentsGroup = orcaPage.getByRole('group', { name: 'Agents' }).first()
+  const closeSessionButton = orcaPage.getByRole('button', { name: 'Close agent session' }).first()
+  await expect(closeSessionButton).toBeAttached({ timeout: 30_000 })
+
+  const agentRow = orcaPage
+    .locator('div[class*="group/agent-row"]')
+    .filter({ has: closeSessionButton })
+    .first()
+
+  // Screenshot 01 — hover the sidebar row so the Square close button fades in.
+  await agentRow.hover()
+  await expect(closeSessionButton).toHaveCSS('opacity', '1', { timeout: 5_000 })
+  const worktreeCard = orcaPage.locator('[role="option"]').filter({ has: agentsGroup }).first()
+  await worktreeCard.screenshot({ path: path.join(SCREENSHOT_DIR, '01-sidebar-row-hover.png') })
+
+  // Screenshot 02 — click opens the confirm dialog; cancel afterwards.
+  await closeSessionButton.click()
+  const sidebarDialog = orcaPage.getByRole('dialog')
+  await expect(sidebarDialog.getByText('Close agent session?')).toBeVisible({ timeout: 10_000 })
+  // Why: let the Radix fade/zoom-in finish or the dialog captures washed out.
+  await expect(sidebarDialog).toHaveCSS('opacity', '1', { timeout: 5_000 })
+  await orcaPage.screenshot({ path: path.join(SCREENSHOT_DIR, '02-sidebar-confirm-dialog.png') })
+  await sidebarDialog.getByRole('button', { name: 'Cancel' }).click()
+  await expect(sidebarDialog).toBeHidden({ timeout: 5_000 })
+
+  // Pop-out dashboard: enable the experimental setting, then open the window.
+  await orcaPage.evaluate(async () => {
+    const settings = (await window.api.settings.set({
+      experimentalAgentDashboardPopout: true
+    })) as Record<string, unknown>
+    window.__store?.setState({ settings })
+  })
+  await orcaPage.evaluate(() => window.api.dashboard.openPopout())
+
+  let popoutPage: Page | null = null
+  await expect
+    .poll(
+      async () => {
+        popoutPage = electronApp.windows().find((w) => w.url().includes('popout.html')) ?? null
+        return popoutPage !== null
+      },
+      { timeout: 15_000, message: 'dashboard pop-out window did not open' }
+    )
+    .toBe(true)
+  if (!popoutPage) {
+    throw new Error('dashboard pop-out window did not open')
+  }
+  await popoutPage.waitForLoadState('domcontentloaded')
+
+  // Why: the close control is a span with role="button" (nested buttons are
+  // invalid HTML); the dialog's confirm is a real <button>, so scope by tag.
+  const cardCloseControl = popoutPage
+    .locator('span[role="button"][aria-label="Close session"]')
+    .first()
+  await expect(cardCloseControl).toBeAttached({ timeout: 30_000 })
+  const kanbanCard = cardCloseControl.locator('xpath=ancestor::button[1]')
+
+  // Screenshot 03 — hover the kanban card so the close X replaces the state dot.
+  await kanbanCard.hover()
+  await expect(cardCloseControl).toHaveCSS('opacity', '1', { timeout: 5_000 })
+  await popoutPage.screenshot({ path: path.join(SCREENSHOT_DIR, '03-popout-card-hover.png') })
+
+  // Screenshot 04 — click opens the confirm dialog in the pop-out; cancel.
+  // Center click: regression cover for the state dot swallowing clicks before
+  // it got pointer-events-none.
+  await cardCloseControl.click()
+  const popoutDialog = popoutPage.getByRole('dialog')
+  await expect(popoutDialog.getByText('Close agent session?')).toBeVisible({ timeout: 10_000 })
+  // Why: let the Radix fade/zoom-in finish or the dialog captures washed out.
+  await expect(popoutDialog).toHaveCSS('opacity', '1', { timeout: 5_000 })
+  await popoutPage.screenshot({ path: path.join(SCREENSHOT_DIR, '04-popout-confirm-dialog.png') })
+  await popoutDialog.getByRole('button', { name: 'Cancel' }).click()
+  await expect(popoutDialog).toBeHidden({ timeout: 5_000 })
+})


### PR DESCRIPTION
## Summary
Lets you close a CLI agent session from the dashboard / sidebar instead of only from the session itself.

- Close action on dashboard agent rows and worktree agent cards
- Confirmation dialog + shared `use-agent-session-close` hook
- i18n (en/es/ja/ko/zh)
- e2e screenshot coverage for the close flow

This is on top of the earlier stop-from-board work; it is the close-session path (`CloseAgentSessionDialog`, `close-dashboard-agent-session.ts`), not the Antigravity quota rebuild in #12095.

## Test plan
- [ ] From the dashboard, close a running CLI session and confirm it actually ends
- [ ] Cancel in the confirmation dialog leaves the session running
- [ ] Sidebar worktree agent card close matches dashboard close
- [ ] e2e `tests/e2e/dashboard-close-agent-screenshot.spec.ts`