### PR TITLE
feat(mobile): nest the host worktree list under project groups

### DIFF
--- a/mobile/scripts/mobile-lag-scenario.ts
+++ b/mobile/scripts/mobile-lag-scenario.ts
@@ -9,6 +9,7 @@ export type MockRepo = {
   path: string
   badgeColor: string
   connectionId: string | null
+  projectGroupId?: string | null
 }
 
 const REPO_COLORS = ['#f97316', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16', '#f59e0b', '#6366f1']
@@ -34,9 +35,39 @@ export function createMockRepos(count: number): MockRepo[] {
       displayName,
       path: `/tmp/orca-mobile-repro/${displayName}`,
       badgeColor: REPO_COLORS[index % REPO_COLORS.length]!,
-      connectionId: null
+      connectionId: null,
+      projectGroupId: index === 0 ? 'mock-work' : index === 1 ? 'mock-personal' : null
     }
   })
+}
+
+export function createMockProjectGroups() {
+  return [
+    {
+      id: 'mock-work',
+      name: 'Work',
+      parentPath: null,
+      parentGroupId: null,
+      createdFrom: 'manual' as const,
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 0,
+      updatedAt: 0
+    },
+    {
+      id: 'mock-personal',
+      name: 'Personal',
+      parentPath: null,
+      parentGroupId: null,
+      createdFrom: 'manual' as const,
+      tabOrder: 1,
+      isCollapsed: false,
+      color: null,
+      createdAt: 0,
+      updatedAt: 0
+    }
+  ]
 }
 
 export function createMockWorktrees(

--- a/mobile/scripts/mock-server-rpc-handlers.ts
+++ b/mobile/scripts/mock-server-rpc-handlers.ts
@@ -14,7 +14,12 @@ import { handleMockAccountRequest } from './mock-server-account-rpc'
 import { handleMockNativeChatRequest } from './mock-server-native-chat-scenario'
 import { handleMockSessionTabsRequest } from './mock-server-session-tabs-fixture'
 import { handleMockTerminalRequest } from './mock-server-terminal-stream'
-import { createMockRepos, createMockWorktrees, readScenarioNumber } from './mobile-lag-scenario'
+import {
+  createMockProjectGroups,
+  createMockRepos,
+  createMockWorktrees,
+  readScenarioNumber
+} from './mobile-lag-scenario'
 
 const MOCK_REPO_COUNT = readScenarioNumber('MOCK_REPO_COUNT', 2)
 const MOCK_WORKTREE_COUNT = readScenarioNumber('MOCK_WORKTREE_COUNT', 2)
@@ -163,6 +168,10 @@ export function handleRequest(
 
     case 'repo.list':
       respond(success(request.id, { repos: FAKE_REPOS }))
+      break
+
+    case 'projectGroup.list':
+      respond(success(request.id, { groups: createMockProjectGroups() }))
       break
 
     case 'settings.get':

--- a/mobile/src/host-screen/host-workspace-list.tsx
+++ b/mobile/src/host-screen/host-workspace-list.tsx
@@ -1,9 +1,7 @@
-import { Pressable, RefreshControl, SectionList, Text, View } from 'react-native'
-import { ChevronDown, ChevronRight, Pin } from 'lucide-react-native'
+import { RefreshControl, SectionList, View } from 'react-native'
 import { AuthFailedBanner } from '../components/AuthFailedBanner'
 import { HostDiagnosticsLink } from '../components/HostDiagnosticsLink'
 import { HostRouteNoticeBanner } from '../components/HostRouteNoticeBanner'
-import { MobileRepoIcon } from '../components/MobileRepoIcon'
 import { MobileSearchField } from '../components/MobileSearchField'
 import { NewWorkspaceFab, FAB_SIZE } from '../components/NewWorkspaceFab'
 import { WorktreeListRow } from '../components/WorktreeListRow'
@@ -14,6 +12,7 @@ import { getWorktreeStatus } from '../worktree/workspace-list-sections'
 import { repoColor } from '../worktree/repo-color'
 import { hostScreenStyles as styles } from './host-screen-styles'
 import type { HostScreenController } from './use-host-screen-controller'
+import { WorkspaceListSectionHeader } from './workspace-list-section-header'
 
 export function HostWorkspaceList({ controller }: { controller: HostScreenController }) {
   const {
@@ -122,36 +121,25 @@ export function HostWorkspaceList({ controller }: { controller: HostScreenContro
             }
             const isCollapsed = state.collapsedGroups.has(section.key)
             const rawSection = rawSections.find((s) => s.key === section.key)
-            const count = rawSection?.data.length ?? 0
-            const repoSectionColor =
-              state.groupMode === 'repo' ? uniqueRepoColors.get(section.title) : null
-            const repoSectionIcon =
-              state.groupMode === 'repo' ? state.repoIconsByName.get(section.title) : null
+            const count = rawSection?.count ?? 0
             return (
-              <Pressable
-                style={styles.sectionHeader}
+              <WorkspaceListSectionHeader
+                title={section.title}
+                count={count}
+                depth={section.depth}
+                kind={section.kind}
+                icon={section.icon}
+                collapsed={isCollapsed}
+                repoColor={
+                  section.kind === 'repo' ? (uniqueRepoColors.get(section.title) ?? null) : null
+                }
+                repoIcon={
+                  section.kind === 'repo'
+                    ? (state.repoIconsByName.get(section.title) ?? null)
+                    : null
+                }
                 onPress={() => settings.toggleCollapsed(section.key)}
-              >
-                {isCollapsed ? (
-                  <ChevronRight size={12} color={colors.textMuted} style={styles.sectionIcon} />
-                ) : (
-                  <ChevronDown size={12} color={colors.textMuted} style={styles.sectionIcon} />
-                )}
-                {section.icon === 'pin' && (
-                  <Pin size={12} color={colors.textMuted} style={styles.sectionIcon} />
-                )}
-                {state.groupMode === 'repo' ? (
-                  <View style={styles.sectionRepoIcon}>
-                    <MobileRepoIcon
-                      repoIcon={repoSectionIcon}
-                      size={14}
-                      color={repoSectionColor ?? colors.textSecondary}
-                    />
-                  </View>
-                ) : null}
-                <Text style={styles.sectionTitle}>{section.title}</Text>
-                <Text style={styles.sectionCount}>{count}</Text>
-              </Pressable>
+              />
             )
           }}
           ItemSeparatorComponent={ListSeparator}

--- a/mobile/src/host-screen/use-host-repo-metadata.ts
+++ b/mobile/src/host-screen/use-host-repo-metadata.ts
@@ -4,6 +4,10 @@ import { setCachedRepos } from '../cache/repo-cache'
 import type { RpcClient } from '../transport/rpc-client'
 import type { ConnectionState, RpcSuccess } from '../transport/types'
 import type { RepoSummary } from '../worktree/host-worktree-rpc-types'
+import {
+  buildRepoProjectGroupIdByRepoId,
+  readProjectGroupListResult
+} from '../worktree/mobile-project-groups'
 import { repoColor } from '../worktree/repo-color'
 import {
   buildHostLabelById,
@@ -63,10 +67,12 @@ export function useHostRepoMetadata(args: {
     repoMetadataFetchedAtRef,
     setHostLabelById,
     setHostPlatform,
+    setProjectGroups,
     setRepoColorsByName,
     setRepoHostIdByRepoId,
     setRepoIconsByName,
-    setRepoIdsByName
+    setRepoIdsByName,
+    setRepoProjectGroupIdByRepoId
   } = state
 
   const fetchRepoMetadata = useCallback(
@@ -90,13 +96,18 @@ export function useHostRepoMetadata(args: {
       try {
         do {
           fetchRepoMetadataPendingRef.current.delete(requestClient)
-          const repoResponse = await requestClient.sendRequest('repo.list')
+          const [repoResponse, projectGroupResult] = await Promise.all([
+            requestClient.sendRequest('repo.list'),
+            requestResult(requestClient, 'projectGroup.list')
+          ])
           if (clientRef.current !== requestClient || hostId !== requestHostId || !repoResponse.ok) {
             return
           }
           const repoResult = (repoResponse as RpcSuccess).result as { repos: RepoSummary[] }
           repoMetadataFetchedAtRef.current = Date.now()
           setCachedRepos(requestHostId, repoResult.repos)
+          setRepoProjectGroupIdByRepoId(buildRepoProjectGroupIdByRepoId(repoResult.repos))
+          setProjectGroups(readProjectGroupListResult(projectGroupResult))
           setRepoColorsByName(
             new Map(
               repoResult.repos.map((repo) => [

--- a/mobile/src/host-screen/use-host-screen-controller.ts
+++ b/mobile/src/host-screen/use-host-screen-controller.ts
@@ -124,7 +124,9 @@ export function useHostScreenController({
     repoIdsByName: state.repoIdsByName,
     repoColorsByName: state.repoColorsByName,
     collapsedGroups: state.collapsedGroups,
-    workspaceStatuses: state.workspaceStatuses
+    workspaceStatuses: state.workspaceStatuses,
+    projectGroups: state.projectGroups,
+    repoProjectGroupIdByRepoId: state.repoProjectGroupIdByRepoId
   })
   const existingWorktreePaths = useMemo(() => state.worktrees.map((w) => w.path), [state.worktrees])
   const activeWorktreeScroll = useActiveWorktreeScroll(sectionsResult.sections)

--- a/mobile/src/host-screen/use-host-screen-state.ts
+++ b/mobile/src/host-screen/use-host-screen-state.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import type { ExecutionHostId } from '../../../src/shared/execution-host'
+import type { ProjectGroup } from '../../../src/shared/project-group-types'
 import type { RepoIcon } from '../../../src/shared/repo-icon'
 import type { WorkspaceStatusDefinition } from '../../../src/shared/worktree/types'
 import { getCachedWorktrees } from '../cache/worktree-cache'
@@ -75,6 +76,10 @@ export function useHostScreenState(hostId: string | undefined, action: string | 
   const [sleptIds, setSleptIds] = useState<Set<string>>(new Set())
   const [pinnedIds, setPinnedIds] = useState<Set<string>>(new Set())
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
+  const [projectGroups, setProjectGroups] = useState<readonly ProjectGroup[]>([])
+  const [repoProjectGroupIdByRepoId, setRepoProjectGroupIdByRepoId] = useState<
+    Map<string, string | null>
+  >(new Map())
   // Why: ref so the ui.get merge and ui.set writes read the latest values without re-creating callbacks on every state change.
   const viewStateRef = useRef<MobileViewState>({
     groupMode: 'repo',
@@ -108,7 +113,9 @@ export function useHostScreenState(hostId: string | undefined, action: string | 
     newWorktreeModalVisibleRef,
     optimisticActiveWorktreeIdentity,
     pinnedIds,
+    projectGroups,
     repoColorsByName,
+    repoProjectGroupIdByRepoId,
     repoHostIdByRepoId,
     repoIconsByName,
     repoIdsByName,
@@ -129,7 +136,9 @@ export function useHostScreenState(hostId: string | undefined, action: string | 
     setLastKnownWorktrees,
     setOptimisticActiveWorktreeIdentity,
     setPinnedIds,
+    setProjectGroups,
     setRepoColorsByName,
+    setRepoProjectGroupIdByRepoId,
     setRepoHostIdByRepoId,
     setRepoIconsByName,
     setRepoIdsByName,

--- a/mobile/src/host-screen/workspace-list-section-header.test.tsx
+++ b/mobile/src/host-screen/workspace-list-section-header.test.tsx
@@ -1,0 +1,54 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { spacing } from '../theme/mobile-theme'
+import { WorkspaceListSectionHeader } from './workspace-list-section-header'
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  StyleSheet: { create: <T,>(styles: T) => styles },
+  Text: 'Text',
+  View: 'View'
+}))
+vi.mock('lucide-react-native', () => ({
+  ChevronDown: 'ChevronDown',
+  ChevronRight: 'ChevronRight',
+  FolderTree: 'FolderTree',
+  Pin: 'Pin'
+}))
+vi.mock('../components/MobileRepoIcon', () => ({ MobileRepoIcon: 'MobileRepoIcon' }))
+
+describe('WorkspaceListSectionHeader', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  it('indents nested project groups and names the collapsed folder for the screen reader', async () => {
+    await act(async () => {
+      renderer = create(
+        createElement(WorkspaceListSectionHeader, {
+          title: 'Clients',
+          count: 2,
+          depth: 1,
+          kind: 'project-group',
+          icon: 'folder',
+          collapsed: true,
+          repoColor: null,
+          repoIcon: null,
+          onPress: () => undefined
+        })
+      )
+    })
+    const pressable = renderer!.root.findByType('Pressable')
+    expect(pressable.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ paddingLeft: spacing.lg + spacing.lg })])
+    )
+    expect(pressable.props.accessibilityLabel).toBe('Clients, 2')
+    expect(pressable.props.accessibilityState).toEqual({ expanded: false })
+    expect(renderer!.root.findByType('FolderTree')).toBeTruthy()
+    expect(renderer!.root.findByType('ChevronRight')).toBeTruthy()
+  })
+})

--- a/mobile/src/host-screen/workspace-list-section-header.tsx
+++ b/mobile/src/host-screen/workspace-list-section-header.tsx
@@ -1,0 +1,50 @@
+import { Pressable, Text, View } from 'react-native'
+import { ChevronDown, ChevronRight, FolderTree, Pin } from 'lucide-react-native'
+import type { RepoIcon } from '../../../src/shared/repo-icon'
+import { MobileRepoIcon } from '../components/MobileRepoIcon'
+import { colors, spacing } from '../theme/mobile-theme'
+import type {
+  WorkspaceListSectionIcon,
+  WorkspaceListSectionKind
+} from '../worktree/workspace-list-types'
+import { hostScreenStyles as styles } from './host-screen-styles'
+
+export function WorkspaceListSectionHeader(props: {
+  title: string
+  count: number
+  depth: number
+  kind: WorkspaceListSectionKind
+  icon?: WorkspaceListSectionIcon
+  collapsed: boolean
+  repoColor: string | null
+  repoIcon: RepoIcon | null
+  onPress: () => void
+}) {
+  const { title, count, depth, kind, icon, collapsed, repoColor, repoIcon, onPress } = props
+  return (
+    <Pressable
+      style={[styles.sectionHeader, { paddingLeft: spacing.lg + depth * spacing.lg }]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${title}, ${count}`}
+      accessibilityState={{ expanded: !collapsed }}
+    >
+      {collapsed ? (
+        <ChevronRight size={12} color={colors.textMuted} style={styles.sectionIcon} />
+      ) : (
+        <ChevronDown size={12} color={colors.textMuted} style={styles.sectionIcon} />
+      )}
+      {icon === 'pin' && <Pin size={12} color={colors.textMuted} style={styles.sectionIcon} />}
+      {icon === 'folder' && (
+        <FolderTree size={12} color={colors.textMuted} style={styles.sectionIcon} />
+      )}
+      {kind === 'repo' ? (
+        <View style={styles.sectionRepoIcon}>
+          <MobileRepoIcon repoIcon={repoIcon} size={14} color={repoColor ?? colors.textSecondary} />
+        </View>
+      ) : null}
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <Text style={styles.sectionCount}>{count}</Text>
+    </Pressable>
+  )
+}

--- a/mobile/src/worktree/host-worktree-rpc-types.ts
+++ b/mobile/src/worktree/host-worktree-rpc-types.ts
@@ -18,4 +18,5 @@ export type RepoSummary = {
   executionHostId?: ExecutionHostId | null
   badgeColor?: string
   repoIcon?: RepoIcon | null
+  projectGroupId?: string | null
 }

--- a/mobile/src/worktree/mobile-project-groups.test.ts
+++ b/mobile/src/worktree/mobile-project-groups.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildRepoProjectGroupIdByRepoId,
+  readProjectGroupListResult,
+  readRepoProjectGroupId
+} from './mobile-project-groups'
+
+describe('mobile project group RPC parse', () => {
+  it('keeps a string membership and drops blanks', () => {
+    expect(readRepoProjectGroupId({ projectGroupId: 'group-1' })).toBe('group-1')
+    expect(readRepoProjectGroupId({ projectGroupId: '' })).toBeNull()
+    expect(readRepoProjectGroupId({})).toBeNull()
+  })
+
+  it('indexes repo.list membership for the section builder', () => {
+    expect([
+      ...buildRepoProjectGroupIdByRepoId([
+        { id: 'repo-1', projectGroupId: 'work' },
+        { id: 'repo-2' }
+      ])
+    ]).toEqual([
+      ['repo-1', 'work'],
+      ['repo-2', null]
+    ])
+  })
+
+  it('normalizes projectGroup.list and ignores junk rows', () => {
+    const groups = readProjectGroupListResult({
+      groups: [
+        { id: 'work', name: 'Work', tabOrder: 1, createdFrom: 'manual' },
+        { id: 'dup', name: 'Dup' },
+        { id: 'dup', name: 'Ignored duplicate' },
+        { name: 'missing-id' },
+        null
+      ]
+    })
+    expect(groups.map((group) => group.id)).toEqual(['dup', 'work'])
+    expect(readProjectGroupListResult(null)).toEqual([])
+    expect(readProjectGroupListResult({ groups: 'nope' })).toEqual([])
+  })
+})

--- a/mobile/src/worktree/mobile-project-groups.ts
+++ b/mobile/src/worktree/mobile-project-groups.ts
@@ -1,0 +1,21 @@
+import type { ProjectGroup } from '../../../src/shared/project-group-types'
+import { normalizeProjectGroups } from '../../../src/shared/project-groups'
+
+export function readRepoProjectGroupId(repo: { projectGroupId?: unknown }): string | null {
+  return typeof repo.projectGroupId === 'string' && repo.projectGroupId.length > 0
+    ? repo.projectGroupId
+    : null
+}
+
+export function buildRepoProjectGroupIdByRepoId(
+  repos: readonly { id: string; projectGroupId?: unknown }[]
+): Map<string, string | null> {
+  return new Map(repos.map((repo) => [repo.id, readRepoProjectGroupId(repo)]))
+}
+
+export function readProjectGroupListResult(result: unknown): ProjectGroup[] {
+  if (!result || typeof result !== 'object') {
+    return []
+  }
+  return normalizeProjectGroups((result as { groups?: unknown }).groups)
+}

--- a/mobile/src/worktree/use-workspace-sections.ts
+++ b/mobile/src/worktree/use-workspace-sections.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
 import type { WorkspaceStatusDefinition } from '../../../src/shared/worktree/types'
 import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
+import type { ProjectGroup } from '../../../src/shared/project-group-types'
+import { collapseWorkspaceListSections } from './workspace-list-collapse'
 import {
   buildSections,
   type FilterState,
@@ -26,6 +28,8 @@ export function useWorkspaceSections(args: {
   repoColorsByName: Map<string, string>
   collapsedGroups: Set<string>
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  projectGroups?: readonly ProjectGroup[]
+  repoProjectGroupIdByRepoId?: ReadonlyMap<string, string | null>
 }): {
   sections: Section[]
   rawSections: Section[]
@@ -42,7 +46,9 @@ export function useWorkspaceSections(args: {
     repoIdsByName,
     repoColorsByName,
     collapsedGroups,
-    workspaceStatuses
+    workspaceStatuses,
+    projectGroups = [],
+    repoProjectGroupIdByRepoId = new Map()
   } = args
 
   const uniqueRepos = useMemo(() => {
@@ -74,7 +80,9 @@ export function useWorkspaceSections(args: {
         pinnedIds,
         repoIdsByName,
         workspaceStatuses,
-        collapsedGroups
+        collapsedGroups,
+        projectGroups,
+        repoProjectGroupIdByRepoId
       ),
     [
       displayWorktrees,
@@ -85,16 +93,14 @@ export function useWorkspaceSections(args: {
       pinnedIds,
       repoIdsByName,
       workspaceStatuses,
-      collapsedGroups
+      collapsedGroups,
+      projectGroups,
+      repoProjectGroupIdByRepoId
     ]
   )
 
   const sections = useMemo(
-    () =>
-      rawSections.map((s) => ({
-        ...s,
-        data: collapsedGroups.has(s.key) ? [] : s.data
-      })),
+    () => collapseWorkspaceListSections(rawSections, collapsedGroups),
     [rawSections, collapsedGroups]
   )
 

--- a/mobile/src/worktree/workspace-list-collapse.test.ts
+++ b/mobile/src/worktree/workspace-list-collapse.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { collapseWorkspaceListSections } from './workspace-list-collapse'
+import type { Section } from './workspace-list-types'
+
+function section(
+  key: string,
+  depth: number,
+  data: string[] = [],
+  kind: Section['kind'] = 'repo'
+): Section {
+  return {
+    key,
+    title: key,
+    kind,
+    depth,
+    count: data.length,
+    data: data.map((worktreeId) => ({ worktreeId }) as Section['data'][number])
+  }
+}
+
+describe('collapseWorkspaceListSections', () => {
+  const tree = [
+    section('project-group:work', 0, [], 'project-group'),
+    section('repo:orca', 1, ['wt-1']),
+    section('project-group:clients', 1, [], 'project-group'),
+    section('repo:client', 2, ['wt-2']),
+    section('repo:notes', 0, ['wt-3'])
+  ]
+
+  it('empties a collapsed section and hides its descendants', () => {
+    const visible = collapseWorkspaceListSections(tree, new Set(['project-group:work']))
+    expect(visible.map((entry) => entry.key)).toEqual(['project-group:work', 'repo:notes'])
+    expect(visible[0]?.data).toEqual([])
+    expect(visible[1]?.data.map((item) => item.worktreeId)).toEqual(['wt-3'])
+  })
+
+  it('can collapse a nested group without hiding its siblings', () => {
+    const visible = collapseWorkspaceListSections(tree, new Set(['project-group:clients']))
+    expect(visible.map((entry) => entry.key)).toEqual([
+      'project-group:work',
+      'repo:orca',
+      'project-group:clients',
+      'repo:notes'
+    ])
+  })
+})

--- a/mobile/src/worktree/workspace-list-collapse.ts
+++ b/mobile/src/worktree/workspace-list-collapse.ts
@@ -1,0 +1,23 @@
+import type { Section } from './workspace-list-types'
+
+export function collapseWorkspaceListSections(
+  sections: readonly Section[],
+  collapsedGroups: ReadonlySet<string>
+): Section[] {
+  const visible: Section[] = []
+  let hideDeeperThan: number | null = null
+  for (const section of sections) {
+    if (hideDeeperThan !== null && section.depth > hideDeeperThan) {
+      continue
+    }
+    hideDeeperThan = null
+    visible.push({
+      ...section,
+      data: collapsedGroups.has(section.key) ? [] : section.data
+    })
+    if (collapsedGroups.has(section.key)) {
+      hideDeeperThan = section.depth
+    }
+  }
+  return visible
+}

--- a/mobile/src/worktree/workspace-list-project-groups-pipeline.test.ts
+++ b/mobile/src/worktree/workspace-list-project-groups-pipeline.test.ts
@@ -1,0 +1,148 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createProjectGroup } from '../../../src/shared/project-groups'
+import { getProjectGroupHeaderKey } from '../../../src/shared/project-groups'
+import { collapseWorkspaceListSections } from './workspace-list-collapse'
+import {
+  buildRepoProjectGroupIdByRepoId,
+  readProjectGroupListResult
+} from './mobile-project-groups'
+import { buildSections, type Worktree } from './workspace-list-sections'
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  const worktreePath = join('/tmp', 'orca', 'worktrees', overrides.displayName ?? 'feature')
+  return {
+    workspaceKind: 'git',
+    worktreeId: overrides.worktreeId ?? `repo-1::${worktreePath}`,
+    repoId: 'repo-1',
+    repo: 'orca',
+    branch: 'feature/mobile-parity',
+    displayName: 'feature',
+    path: worktreePath,
+    liveTerminalCount: 0,
+    hasAttachedPty: false,
+    preview: '',
+    unread: false,
+    isPinned: false,
+    linkedPR: null,
+    status: 'inactive',
+    agents: [],
+    ...overrides
+  }
+}
+
+describe('mobile workspace list project-group pipeline', () => {
+  const work = createProjectGroup({ name: 'Work', createdFrom: 'manual', tabOrder: 0 })
+  const clients = createProjectGroup({
+    name: 'Clients',
+    createdFrom: 'manual',
+    tabOrder: 0,
+    parentGroupId: work.id
+  })
+
+  const repoList = {
+    repos: [
+      { id: 'repo-1', displayName: 'orca', projectGroupId: work.id },
+      { id: 'repo-2', displayName: 'client', projectGroupId: clients.id },
+      { id: 'repo-3', displayName: 'notes' }
+    ]
+  }
+  const groupList = { groups: [work, clients] }
+
+  it('projects repo.list + projectGroup.list + worktree.ps into the desktop nest and collapse keys', () => {
+    const projectGroups = readProjectGroupListResult(groupList)
+    const repoProjectGroupIdByRepoId = buildRepoProjectGroupIdByRepoId(repoList.repos)
+    const worktrees = [
+      worktree({
+        worktreeId: 'orca-main',
+        repoId: 'repo-1',
+        repo: 'orca',
+        displayName: 'main',
+        isMainWorktree: true
+      }),
+      worktree({
+        worktreeId: 'client-feat',
+        repoId: 'repo-2',
+        repo: 'client',
+        displayName: 'feat'
+      }),
+      worktree({
+        worktreeId: 'notes-main',
+        repoId: 'repo-3',
+        repo: 'notes',
+        displayName: 'notes'
+      })
+    ]
+
+    const raw = buildSections(
+      worktrees,
+      'manual',
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      '',
+      'repo',
+      new Set(),
+      new Map(repoList.repos.map((repo) => [repo.displayName, repo.id])),
+      [],
+      new Set(),
+      projectGroups,
+      repoProjectGroupIdByRepoId
+    )
+
+    expect(
+      raw.map((section) => ({
+        key: section.key,
+        title: section.title,
+        kind: section.kind,
+        depth: section.depth
+      }))
+    ).toEqual([
+      {
+        key: getProjectGroupHeaderKey(work.id),
+        title: 'Work',
+        kind: 'project-group',
+        depth: 0
+      },
+      { key: 'repo:repo-1', title: 'orca', kind: 'repo', depth: 1 },
+      {
+        key: getProjectGroupHeaderKey(clients.id),
+        title: 'Clients',
+        kind: 'project-group',
+        depth: 1
+      },
+      { key: 'repo:repo-2', title: 'client', kind: 'repo', depth: 2 },
+      { key: 'repo:repo-3', title: 'notes', kind: 'repo', depth: 0 }
+    ])
+    expect(
+      raw.find((section) => section.key === 'repo:repo-1')?.data.map((row) => row.worktreeId)
+    ).toEqual(['orca-main'])
+
+    const collapsed = collapseWorkspaceListSections(
+      raw,
+      new Set([getProjectGroupHeaderKey(work.id)])
+    )
+    expect(collapsed.map((section) => section.key)).toEqual([
+      getProjectGroupHeaderKey(work.id),
+      'repo:repo-3'
+    ])
+    expect(collapsed.flatMap((section) => section.data.map((row) => row.worktreeId))).toEqual([
+      'notes-main'
+    ])
+  })
+
+  it('does not nest project groups outside repo grouping', () => {
+    const sections = buildSections(
+      [worktree({ worktreeId: 'orca-main', repoId: 'repo-1', repo: 'orca' })],
+      'manual',
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      '',
+      'none',
+      new Set(),
+      new Map([['orca', 'repo-1']]),
+      [],
+      new Set(),
+      readProjectGroupListResult(groupList),
+      buildRepoProjectGroupIdByRepoId(repoList.repos)
+    )
+    expect(sections.map((section) => section.key)).toEqual(['all'])
+  })
+})

--- a/mobile/src/worktree/workspace-list-project-groups.test.ts
+++ b/mobile/src/worktree/workspace-list-project-groups.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { createProjectGroup, getProjectGroupHeaderKey } from '../../../src/shared/project-groups'
+import { nestRepoSectionsInProjectGroups } from './workspace-list-project-groups'
+import type { Section, Worktree } from './workspace-list-types'
+
+function repoSection(repoId: string, title: string): Section {
+  return {
+    key: `repo:${repoId}`,
+    title,
+    kind: 'repo',
+    depth: 0,
+    count: 1,
+    data: [{ worktreeId: repoId, repoId, repo: title } as Worktree]
+  }
+}
+
+describe('nestRepoSectionsInProjectGroups', () => {
+  const work = createProjectGroup({ name: 'Work', createdFrom: 'manual', tabOrder: 0 })
+  const clients = createProjectGroup({
+    name: 'Clients',
+    createdFrom: 'manual',
+    tabOrder: 0,
+    parentGroupId: work.id
+  })
+  const personal = createProjectGroup({ name: 'Personal', createdFrom: 'manual', tabOrder: 1 })
+
+  it('keeps a flat repo list when the host has no project groups', () => {
+    const sections = nestRepoSectionsInProjectGroups({
+      repoSections: [repoSection('repo-1', 'orca')],
+      projectGroups: [],
+      repoProjectGroupIdByRepoId: new Map([['repo-1', 'missing']])
+    })
+    expect(sections.map((section) => section.key)).toEqual(['repo:repo-1'])
+    expect(sections[0]?.depth).toBe(0)
+  })
+
+  it('nests repos under desktop project-group keys and leaves ungrouped repos at the root', () => {
+    const sections = nestRepoSectionsInProjectGroups({
+      repoSections: [
+        repoSection('repo-1', 'orca'),
+        repoSection('repo-2', 'notes'),
+        repoSection('repo-3', 'client')
+      ],
+      projectGroups: [work, clients, personal],
+      repoProjectGroupIdByRepoId: new Map([
+        ['repo-1', work.id],
+        ['repo-2', personal.id],
+        ['repo-3', clients.id]
+      ])
+    })
+
+    expect(
+      sections.map((section) => ({
+        key: section.key,
+        title: section.title,
+        kind: section.kind,
+        depth: section.depth,
+        count: section.count
+      }))
+    ).toEqual([
+      {
+        key: getProjectGroupHeaderKey(work.id),
+        title: 'Work',
+        kind: 'project-group',
+        depth: 0,
+        count: 2
+      },
+      { key: 'repo:repo-1', title: 'orca', kind: 'repo', depth: 1, count: 1 },
+      {
+        key: getProjectGroupHeaderKey(clients.id),
+        title: 'Clients',
+        kind: 'project-group',
+        depth: 1,
+        count: 1
+      },
+      { key: 'repo:repo-3', title: 'client', kind: 'repo', depth: 2, count: 1 },
+      {
+        key: getProjectGroupHeaderKey(personal.id),
+        title: 'Personal',
+        kind: 'project-group',
+        depth: 0,
+        count: 1
+      },
+      { key: 'repo:repo-2', title: 'notes', kind: 'repo', depth: 1, count: 1 }
+    ])
+  })
+
+  it('shows empty project groups and treats unknown membership as ungrouped', () => {
+    const empty = createProjectGroup({ name: 'Empty', createdFrom: 'manual', tabOrder: 2 })
+    const sections = nestRepoSectionsInProjectGroups({
+      repoSections: [repoSection('repo-1', 'orca')],
+      projectGroups: [work, empty],
+      repoProjectGroupIdByRepoId: new Map([['repo-1', 'ghost-group']])
+    })
+
+    expect(sections.map((section) => section.key)).toEqual([
+      getProjectGroupHeaderKey(work.id),
+      getProjectGroupHeaderKey(empty.id),
+      'repo:repo-1'
+    ])
+    expect(sections[2]?.depth).toBe(0)
+  })
+})

--- a/mobile/src/worktree/workspace-list-project-groups.ts
+++ b/mobile/src/worktree/workspace-list-project-groups.ts
@@ -1,0 +1,92 @@
+import type { ProjectGroup } from '../../../src/shared/project-group-types'
+import { getProjectGroupHeaderKey } from '../../../src/shared/project-groups'
+import type { Section } from './workspace-list-types'
+
+function repoIdFromSectionKey(key: string): string {
+  return key.startsWith('repo:') ? key.slice('repo:'.length) : key
+}
+
+function sortProjectGroups(groups: readonly ProjectGroup[]): ProjectGroup[] {
+  return [...groups].sort(
+    (left, right) => left.tabOrder - right.tabOrder || left.name.localeCompare(right.name)
+  )
+}
+
+export function nestRepoSectionsInProjectGroups(args: {
+  repoSections: readonly Section[]
+  projectGroups: readonly ProjectGroup[]
+  repoProjectGroupIdByRepoId: ReadonlyMap<string, string | null>
+}): Section[] {
+  const { repoSections, projectGroups, repoProjectGroupIdByRepoId } = args
+  if (projectGroups.length === 0) {
+    return repoSections.map((section) => ({ ...section, kind: 'repo' as const, depth: 0 }))
+  }
+
+  const groupsById = new Map(projectGroups.map((group) => [group.id, group]))
+  const sectionsByGroupId = new Map<string | null, Section[]>()
+  for (const section of repoSections) {
+    const repoId = repoIdFromSectionKey(section.key)
+    const membership = repoProjectGroupIdByRepoId.get(repoId) ?? null
+    const groupId = membership && groupsById.has(membership) ? membership : null
+    const list = sectionsByGroupId.get(groupId) ?? []
+    list.push(section)
+    sectionsByGroupId.set(groupId, list)
+  }
+
+  const childrenByParentId = new Map<string | null, ProjectGroup[]>()
+  for (const group of projectGroups) {
+    const parentId =
+      group.parentGroupId && groupsById.has(group.parentGroupId) ? group.parentGroupId : null
+    const children = childrenByParentId.get(parentId) ?? []
+    children.push(group)
+    childrenByParentId.set(parentId, children)
+  }
+  for (const children of childrenByParentId.values()) {
+    children.sort(
+      (left, right) => left.tabOrder - right.tabOrder || left.name.localeCompare(right.name)
+    )
+  }
+
+  const getSubtreeCount = (groupId: string): number => {
+    const direct = sectionsByGroupId.get(groupId)?.length ?? 0
+    const children = childrenByParentId.get(groupId) ?? []
+    return children.reduce((count, child) => count + getSubtreeCount(child.id), direct)
+  }
+
+  const result: Section[] = []
+  const appendProjectGroup = (projectGroup: ProjectGroup, depth: number): void => {
+    const key = getProjectGroupHeaderKey(projectGroup.id)
+    result.push({
+      key,
+      title: projectGroup.name,
+      kind: 'project-group',
+      depth,
+      icon: 'folder',
+      count: getSubtreeCount(projectGroup.id),
+      data: []
+    })
+    for (const section of sectionsByGroupId.get(projectGroup.id) ?? []) {
+      result.push({ ...section, kind: 'repo', depth: depth + 1 })
+    }
+    for (const child of childrenByParentId.get(projectGroup.id) ?? []) {
+      appendProjectGroup(child, depth + 1)
+    }
+    sectionsByGroupId.delete(projectGroup.id)
+  }
+
+  for (const root of sortProjectGroups(childrenByParentId.get(null) ?? [])) {
+    appendProjectGroup(root, 0)
+  }
+
+  const remaining = [...(sectionsByGroupId.get(null) ?? [])]
+  for (const [groupId, sections] of sectionsByGroupId) {
+    if (groupId === null || groupsById.has(groupId)) {
+      continue
+    }
+    remaining.push(...sections)
+  }
+  for (const section of remaining) {
+    result.push({ ...section, kind: 'repo', depth: 0 })
+  }
+  return result
+}

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -34,7 +34,7 @@ function worktree(overrides: Partial<Worktree> = {}): Worktree {
 }
 
 function withoutSectionListKeys(sections: ReturnType<typeof buildSections>) {
-  return sections.map((section) => ({
+  return sections.map(({ kind: _kind, depth: _depth, count: _count, ...section }) => ({
     ...section,
     data: section.data.map(
       ({

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -7,8 +7,16 @@ import {
 } from './mobile-workspace-statuses'
 import { applyMobileWorkspaceLineage } from './mobile-workspace-lineage'
 import { getPRGroupKey, PR_GROUP_LABELS, PR_GROUP_ORDER } from './workspace-pr-status-groups'
-import type { FilterState, Section, Worktree } from './workspace-list-types'
+import type { ProjectGroup } from '../../../src/shared/project-group-types'
+import type {
+  FilterState,
+  Section,
+  Worktree,
+  WorkspaceListSectionIcon,
+  WorkspaceListSectionKind
+} from './workspace-list-types'
 import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
+import { nestRepoSectionsInProjectGroups } from './workspace-list-project-groups'
 import { sortWorktrees } from './workspace-list-ordering'
 import { getWorktreeRowIdentity } from './worktree-host-row-identity'
 
@@ -19,18 +27,23 @@ function makeSection(
   key: string,
   title: string,
   data: Worktree[],
-  icon?: 'pin',
+  kind: WorkspaceListSectionKind,
+  icon?: WorkspaceListSectionIcon,
   collapsedGroups?: ReadonlySet<string>
 ): Section {
   const rows = collapsedGroups ? applyMobileWorkspaceLineage(data, collapsedGroups) : data
+  const rowsWithKeys = rows.map((worktree) => ({
+    ...worktree,
+    sectionListKey: `${key}:${getWorktreeRowIdentity(worktree)}`
+  }))
   return {
     key,
     title,
+    kind,
+    depth: 0,
+    count: rowsWithKeys.length,
     ...(icon ? { icon } : {}),
-    data: rows.map((worktree) => ({
-      ...worktree,
-      sectionListKey: `${key}:${getWorktreeRowIdentity(worktree)}`
-    }))
+    data: rowsWithKeys
   }
 }
 
@@ -129,7 +142,9 @@ export function buildSections(
   pinnedIds: Set<string>,
   repoIdsByName: ReadonlyMap<string, string> = new Map(),
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = DEFAULT_MOBILE_WORKSPACE_STATUSES,
-  collapsedGroups: ReadonlySet<string> = new Set()
+  collapsedGroups: ReadonlySet<string> = new Set(),
+  projectGroups: readonly ProjectGroup[] = [],
+  repoProjectGroupIdByRepoId: ReadonlyMap<string, string | null> = new Map()
 ): Section[] {
   const filtered = filterWorktrees(worktrees, filters, search)
   const sorted = sortWorktrees(filtered, sortMode)
@@ -141,12 +156,14 @@ export function buildSections(
 
   const sections: Section[] = []
   if (pinned.length > 0) {
-    sections.push(makeSection('pinned', 'Pinned', pinned, 'pin'))
+    sections.push(makeSection('pinned', 'Pinned', pinned, 'pinned', 'pin'))
   }
 
   if (groupMode === 'none') {
     if (canonicalGroupWorktrees.length > 0) {
-      sections.push(makeSection('all', 'All', canonicalGroupWorktrees, undefined, collapsedGroups))
+      sections.push(
+        makeSection('all', 'All', canonicalGroupWorktrees, 'lane', undefined, collapsedGroups)
+      )
     }
   } else if (groupMode === 'repo') {
     const byRepo = new Map<string, Worktree[]>()
@@ -175,12 +192,20 @@ export function buildSections(
         byRepo.set(displayName, [])
       }
     }
+    const repoSections: Section[] = []
     for (const [repo, items] of byRepo) {
       const key = `repo:${repoIdsByName.get(repo) ?? repo}`
-      sections.push(
-        makeSection(key, repo, orderMainWorktreeFirst(items), undefined, collapsedGroups)
+      repoSections.push(
+        makeSection(key, repo, orderMainWorktreeFirst(items), 'repo', undefined, collapsedGroups)
       )
     }
+    sections.push(
+      ...nestRepoSectionsInProjectGroups({
+        repoSections,
+        projectGroups,
+        repoProjectGroupIdByRepoId
+      })
+    )
   } else if (groupMode === 'workspaceStatus') {
     const renderableWorkspaceStatuses = coerceMobileWorkspaceStatuses(workspaceStatuses)
     const byStatus = new Map<string, Worktree[]>()
@@ -201,6 +226,7 @@ export function buildSections(
             getMobileWorkspaceStatusGroupKey(status.id),
             status.label,
             items,
+            'lane',
             undefined,
             collapsedGroups
           )
@@ -226,6 +252,7 @@ export function buildSections(
             `pr:${groupKey}`,
             PR_GROUP_LABELS[groupKey],
             items,
+            'lane',
             undefined,
             collapsedGroups
           )

--- a/mobile/src/worktree/workspace-list-types.ts
+++ b/mobile/src/worktree/workspace-list-types.ts
@@ -62,4 +62,15 @@ export type FilterState = {
   alwaysShowDefaultBranch?: boolean
 }
 
-export type Section = { key: string; title: string; icon?: 'pin'; data: Worktree[] }
+export type WorkspaceListSectionKind = 'pinned' | 'lane' | 'project-group' | 'repo'
+export type WorkspaceListSectionIcon = 'pin' | 'folder'
+
+export type Section = {
+  key: string
+  title: string
+  kind: WorkspaceListSectionKind
+  depth: number
+  icon?: WorkspaceListSectionIcon
+  count: number
+  data: Worktree[]
+}

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
@@ -9,7 +9,6 @@ import {
   ConductorProgressIcon,
   ConductorReviewIcon
 } from '../../workspace-status-icons'
-import { UNGROUPED_PROJECT_GROUP_KEY } from '../../../../../../shared/project-groups'
 import type { AppState } from '../../../../store/types'
 import {
   getGitHubPRCacheKey,
@@ -17,6 +16,8 @@ import {
 } from '../../../../store/slices/github-cache-key'
 import { translate } from '@/i18n/i18n'
 import { isGitHubPRSuppressed } from '../../../../../../shared/worktree/github-pr-suppression'
+
+export { getProjectGroupHeaderKey } from '../../../../../../shared/project-groups'
 
 export type PRGroupKey = 'done' | 'in-review' | 'in-progress' | 'closed'
 
@@ -70,10 +71,6 @@ export const PROJECT_GROUP_META = {
   tone: 'text-foreground',
   icon: FolderTree
 } as const
-
-export function getProjectGroupHeaderKey(groupId: string | null): string {
-  return groupId ? `project-group:${groupId}` : UNGROUPED_PROJECT_GROUP_KEY
-}
 
 export const PINNED_GROUP_KEY = 'pinned'
 

--- a/src/shared/project-groups.ts
+++ b/src/shared/project-groups.ts
@@ -4,6 +4,10 @@ import type { Repo } from './repo-types'
 
 export const UNGROUPED_PROJECT_GROUP_KEY = 'project-group:ungrouped'
 
+export function getProjectGroupHeaderKey(groupId: string | null): string {
+  return groupId ? `project-group:${groupId}` : UNGROUPED_PROJECT_GROUP_KEY
+}
+
 function createProjectGroupId(): string {
   const randomUUID = globalThis.crypto?.randomUUID
   if (randomUUID) {


### PR DESCRIPTION
## Why
Desktop already folders repos under Project Groups when Group by is Repository. Mobile listed every repo in one flat `SectionList`, so a phone user with the same catalog could not fold Work / Personal / nested folders or share `collapsedGroups` with desktop.

## Scope
- `Section` now has `kind`, `depth`, and a required `count`.
- `buildSections` still builds repo lanes. `nestRepoSectionsInProjectGroups` wraps them when `groupMode === 'repo'` and `projectGroup.list` returns groups.
- `useHostRepoMetadata` fetches `projectGroup.list` next to `repo.list` and keeps `projectGroupId` from each repo.
- Collapse uses `getProjectGroupHeaderKey` from `src/shared/project-groups.ts` (desktop `group-keys.ts` re-exports it). Folding a parent hides descendants.
- `WorkspaceListSectionHeader` indents by depth and names the folder for VoiceOver.
- Pipeline test walks repo.list + projectGroup.list + worktree.ps through nest and collapse. Header render test checks indent and `Clients, 2`.
- Mock server answers `projectGroup.list` so local Expo can show folders.

Out of scope: create, rename, move, or drag groups. Status and PR grouping stay flat, same as desktop. Folder workspaces nest only when `repo.list` carries `projectGroupId`.

## Tradeoffs
Kept `SectionList` instead of porting desktop `buildRows` onto a `FlatList`. The desktop row union also carries imported-worktree cards, pending creates, and drag. The phone does not need those.

## Blast Radius
Phone host workspace list only, plus the shared header-key helper. Old hosts that lack `projectGroup.list` keep today's flat repo sections. Mixed clients already persist `collapsedGroups` as strings. Matching keys is what makes a desktop fold stick on the phone.

## Verification
- `pnpm --dir mobile test` on the grouping files. 51 passed, including `workspace-list-project-groups-pipeline.test.ts`.
- `WorkspaceListSectionHeader` render test. Depth 1 uses `paddingLeft: 32`.
- `pnpm --dir mobile typecheck` passed.
- Changed-code quality gate passed.
- Desktop `folder-reveal` and nested project-group tests passed after the key move.
- No Maestro or Detox harness in this repo. A real phone pass on a paired host with Project Groups is still needed.


Made with [Cursor](https://cursor.com)