### PR TITLE
feat(agents): register DeepSeek in the TUI agent catalog

### DIFF
--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -133,7 +133,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   grok: true,
   devin: true,
   ante: true,
-  trae: true
+  trae: true,
+  deepseek: true
 }
 
 // Why: return null (not a 'claude' fallback) for unknown so Codex panes don't flash the Claude icon before the hook fires.

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -49,7 +49,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   grok: 'grok',
   devin: 'devin',
   ante: 'ante',
-  trae: 'trae'
+  trae: 'trae',
+  deepseek: 'deepseek'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -191,6 +191,38 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('kimi-code')).toBe(true)
   })
 
+  it('recognizes DeepSeek by the deepseek-tui process its dispatcher becomes', () => {
+    expect(recognizeAgentProcess('/usr/bin/deepseek')).toEqual({
+      agent: 'deepseek',
+      processName: 'deepseek'
+    })
+    expect(recognizeAgentProcess('deepseek-tui')).toEqual({
+      agent: 'deepseek',
+      processName: 'deepseek-tui'
+    })
+    expect(isExpectedAgentProcess('/usr/bin/deepseek-tui', 'deepseek-tui')).toBe(true)
+    expect(isRecognizedAgentType('deepseek-tui')).toBe(true)
+    // Why: `deepseek` is the CLI id; model ids that share the prefix are not agents.
+    expect(isRecognizedAgentType('deepseek-v4-flash')).toBe(false)
+  })
+
+  it('recognizes the DeepSeek npm entrypoints launched through node', () => {
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`node C:\Users\dev\AppData\Roaming\npm\node_modules\deepseek-tui\bin\deepseek.js`
+      )
+    ).toEqual({ agent: 'deepseek', processName: 'deepseek' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        '/usr/bin/node /usr/lib/node_modules/deepseek-tui/bin/deepseek-tui.js'
+      )
+    ).toEqual({ agent: 'deepseek', processName: 'deepseek-tui' })
+    // Why: the package name must not make any unrelated node script a DeepSeek identity.
+    expect(
+      recognizeAgentProcessFromCommandLine(String.raw`node C:\repo\deepseek-tui\bin\deepseek.js`)
+    ).toBeNull()
+  })
+
   it('recognizes Qwen Code by its installed qwen executable', () => {
     expect(recognizeAgentProcess('/home/dev/.local/bin/qwen')).toEqual({
       agent: 'qwen-code',

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -51,6 +51,10 @@ const INTERPRETER_OPTIONS_WITH_VALUE = new Set([
 const INTERPRETER_OPTIONS_WITH_INLINE_SOURCE = new Set(['-e', '--eval', '-p', '--print', '--check'])
 const NODE_PACKAGE_SCRIPT_ENTRYPOINTS: Record<string, readonly string[]> = {
   codex: ['node_modules/@openai/codex/'],
+  // Why: npm's Windows shims launch the package's own `bin/*.js` by resolved path, so
+  // both DeepSeek entrypoints arrive as `deepseek.js` / `deepseek-tui.js` basenames.
+  deepseek: ['node_modules/deepseek-tui/'],
+  'deepseek-tui': ['node_modules/deepseek-tui/'],
   gemini: ['node_modules/@google/gemini-cli/']
 }
 const PYTHON_SCRIPT_ENTRYPOINT_DIRECTORIES = ['/bin/', '/scripts/', '/site-packages/']

--- a/src/shared/skills-cli-agent-keys.ts
+++ b/src/shared/skills-cli-agent-keys.ts
@@ -49,7 +49,8 @@ export const SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT = {
   devin: 'devin',
   ante: null,
   // Why: Orca detects trae by `traecli`, an alias only TRAE CN ships.
-  trae: 'trae-cn'
+  trae: 'trae-cn',
+  deepseek: null
 } satisfies Record<TuiAgent, string | null>
 
 /**

--- a/src/shared/telemetry-property-schemas.ts
+++ b/src/shared/telemetry-property-schemas.ts
@@ -44,6 +44,7 @@ export const AGENT_KIND_VALUES = [
   'devin',
   'ante',
   'trae',
+  'deepseek',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.test.ts
+++ b/src/shared/tui-agent-config.test.ts
@@ -23,6 +23,7 @@ describe('TUI_AGENT_CONFIG', () => {
       'claude-agent-teams': { launchCmd: 'orca claude-teams', expectedProcess: 'claude' },
       kiro: { launchCmd: 'kiro-cli chat --tui', expectedProcess: 'kiro-cli' },
       'command-code': { launchCmd: 'command-code --trust' },
+      deepseek: { launchCmd: 'deepseek --skip-onboarding', expectedProcess: 'deepseek-tui' },
       hermes: { launchCmd: 'hermes --tui' }
     }
     for (const [agent, expected] of Object.entries(overrides)) {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -225,6 +225,18 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
     // Why: first-launch trust menu swallows the bracketed paste; pre-write the .workspace-trusted marker so it skips (agent-trust-presets.ts).
     preflightTrust: 'cursor'
   },
+  deepseek: {
+    detectCmd: 'deepseek',
+    // Why: the npm package installs both shims on PATH and the launcher runs as
+    // `deepseek-tui`, so without the alias PATH detection misses wrapped installs.
+    detectCmdAliases: ['deepseek-tui'],
+    // Why: `--skip-onboarding` stops the first-run onboarding flow from consuming the task text.
+    launchCmd: 'deepseek --skip-onboarding',
+    // Why: the `deepseek` dispatcher delegates the interactive session to a sibling
+    // `deepseek-tui` binary, so the foreground process is never named `deepseek`.
+    expectedProcess: 'deepseek-tui',
+    promptInjectionMode: 'stdin-after-start'
+  },
   droid: {
     detectCmd: 'droid',
     promptInjectionMode: 'argv',

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -41,7 +41,8 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   hermes: 'Hermes',
   openclaw: 'OpenClaw',
   copilot: 'GitHub Copilot',
-  grok: 'Grok'
+  grok: 'Grok',
+  deepseek: 'DeepSeek'
 }
 
 /** Canonical agent id list derived from the exhaustive display-name record,

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -39,7 +39,8 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'rovo',
   'hermes',
   'devin',
-  'openclaw'
+  'openclaw',
+  'deepseek'
 ] as const satisfies readonly TuiAgent[]
 
 // Why: fresh installs should expose Claude Agent Teams in agent pickers; the

--- a/src/shared/tui-agent.ts
+++ b/src/shared/tui-agent.ts
@@ -24,6 +24,7 @@ export type TuiAgent =
   | 'command-code' // Command Code
   | 'continue' // Continue
   | 'cursor' // Cursor
+  | 'deepseek' // DeepSeek CLI
   | 'droid' // Factory Droid
   | 'kimi' // Kimi
   | 'mistral-vibe' // Mistral Vibe


### PR DESCRIPTION
## Summary

Registers \`deepseek\` as a TUI agent and recognizes the \`deepseek-tui\` foreground process used by its dispatcher. It also recognizes the resolved \`node_modules/deepseek-tui/bin/*.js\` entrypoints used by npm Windows shims.

The launcher uses \`deepseek --skip-onboarding\`, \`expectedProcess: deepseek-tui\`, and \`stdin-after-start\`; this does not add a model catalog or launch DeepSeek.

## Validation

### Initial patch (commit \`cb2c199409\`) — 5 files

- \`pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-process-recognition.test.ts src/shared/tui-agent-config.test.ts\` — 31 passed
- \`pnpm run typecheck:tsc\` — passed
- Patch clean-applies to annotated tag \`v1.4.200\` (\`f352b6b0\`) and current main (\`403b62a8\`).

### Gap-close (commit \`ca5f63dd28\`) — 6 additional files

Completes exhaustive \`Record<TuiAgent, ...>\` mappings that blocked CLI/desktop typecheck after \`deepseek\` was added to the \`TuiAgent\` union:

| File | Addition |
|------|---------|
| \`src/shared/agent-kind.ts\` | \`deepseek: 'deepseek'\` |
| \`src/shared/skills-cli-agent-keys.ts\` | \`deepseek: null\` |
| \`src/shared/tui-agent-display-names.ts\` | \`deepseek: 'DeepSeek'\` |
| \`src/shared/telemetry-property-schemas.ts\` | \`'deepseek'\` in \`AGENT_KIND_VALUES\` |
| \`src/shared/tui-agent-selection.ts\` | \`'deepseek'\` in \`TUI_AGENT_AUTO_PICK_ORDER\` |
| \`src/renderer/src/lib/agent-status.ts\` | \`deepseek: true\` |

- \`npx tsc -p config/tsconfig.cli.json --noEmit\` → 0 errors
- Tests: \`Test Files 2 passed (2) | Tests 31 passed (31)\`
- Relay build: all 6 platform targets + WSL — SHA256 \`b2979c63fc9608b904d55d9e35346c01805769547d4327583a473c6bae2a880a\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)