### PR TITLE
fix(agents): re-probe remote hosts when a launch surface mounts

### DIFF
--- a/src/renderer/src/hooks/composer-state/identity-model.ts
+++ b/src/renderer/src/hooks/composer-state/identity-model.ts
@@ -50,6 +50,9 @@ export type ComposerIdentityModel = {
     connectionId: string,
     options?: { force?: boolean }
   ) => Promise<TuiAgent[]>
-  ensureRuntimeDetectedAgents: (environmentId: string) => Promise<TuiAgent[]>
+  ensureRuntimeDetectedAgents: (
+    environmentId: string,
+    options?: { force?: boolean }
+  ) => Promise<TuiAgent[]>
   detectedAgentIds: Set<TuiAgent> | null
 }

--- a/src/renderer/src/hooks/useDetectedAgents.test.tsx
+++ b/src/renderer/src/hooks/useDetectedAgents.test.tsx
@@ -237,6 +237,41 @@ describe('useDetectedAgents (ssh call site)', () => {
     expect(detectRemoteAgents).toHaveBeenCalledTimes(2)
     expect(useAppStore.getState().remoteDetectedAgentIds['ssh-1']).toEqual(['kilo'])
   })
+
+  it('re-probes a cached non-empty SSH list when the launch surface is reopened', async () => {
+    detectRemoteAgents.mockResolvedValue(['claude'])
+    const firstRoot = await renderProbe({ kind: 'ssh', connectionId: 'ssh-1' })
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+    expect(useAppStore.getState().remoteDetectedAgentIds['ssh-1']).toEqual(['claude'])
+
+    await act(async () => {
+      firstRoot.unmount()
+    })
+    roots.splice(roots.indexOf(firstRoot), 1)
+
+    // A CLI installed after the first probe must show up on the next surface.
+    detectRemoteAgents.mockResolvedValue(['claude', 'devin'])
+
+    await renderProbe({ kind: 'ssh', connectionId: 'ssh-1' })
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(2)
+    expect(useAppStore.getState().remoteDetectedAgentIds['ssh-1']).toEqual(['claude', 'devin'])
+  })
+
+  it('keeps a non-empty SSH target to one probe per mounted surface', async () => {
+    detectRemoteAgents.mockResolvedValue(['claude'])
+    const root = await renderProbe({ kind: 'ssh', connectionId: 'ssh-1' })
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      root.render(createElement(HookProbe, { target: { kind: 'ssh', connectionId: 'ssh-1' } }))
+    })
+    await flushEffects()
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('useDetectedAgents (unresolved target)', () => {
@@ -325,15 +360,19 @@ describe('useDetectedAgents (runtime call site)', () => {
     })
 
     await renderProbe({ kind: 'runtime', environmentId: 'env-1' })
-    await renderProbe({ kind: 'runtime', environmentId: 'env-1' })
     await act(async () => {
       await latestHookResult?.refresh()
     })
     await flushEffects()
 
     expect(refreshCalls).toBe(1)
-    expect(detectCalls).toBe(0)
     expect(useAppStore.getState().runtimeDetectedAgentIds['env-1']).toEqual([])
+
+    // Why: a refresh that clears the list must settle — the mounted surface
+    // must not bounce into another probe loop from the new detectedIds value.
+    const detectCallsAfterRefresh = detectCalls
+    await flushEffects()
+    expect(detectCalls).toBe(detectCallsAfterRefresh)
   })
 
   it('retries a cached empty runtime result when the launch surface is reopened', async () => {
@@ -377,5 +416,48 @@ describe('useDetectedAgents (runtime call site)', () => {
 
     expect(detectCalls).toBe(2)
     expect(useAppStore.getState().runtimeDetectedAgentIds['env-1']).toEqual(['kilo'])
+  })
+
+  it('re-probes a cached non-empty runtime list when the launch surface is reopened', async () => {
+    let detectCalls = 0
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+      let result: unknown
+      if (method === 'status.get') {
+        result = {
+          runtimeId: 'remote-runtime',
+          rendererGraphEpoch: 1,
+          graphStatus: 'ready',
+          authoritativeWindowId: null,
+          liveTabCount: 0,
+          liveLeafCount: 0,
+          runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+          minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+        }
+      } else {
+        detectCalls += 1
+        result = detectCalls === 1 ? ['claude'] : ['claude', 'devin']
+      }
+      return Promise.resolve({
+        id: method,
+        ok: true,
+        result,
+        _meta: { runtimeId: 'remote-runtime' }
+      })
+    })
+
+    const firstRoot = await renderProbe({ kind: 'runtime', environmentId: 'env-1' })
+
+    expect(detectCalls).toBe(1)
+    expect(useAppStore.getState().runtimeDetectedAgentIds['env-1']).toEqual(['claude'])
+
+    await act(async () => {
+      firstRoot.unmount()
+    })
+    roots.splice(roots.indexOf(firstRoot), 1)
+
+    await renderProbe({ kind: 'runtime', environmentId: 'env-1' })
+
+    expect(detectCalls).toBe(2)
+    expect(useAppStore.getState().runtimeDetectedAgentIds['env-1']).toEqual(['claude', 'devin'])
   })
 })

--- a/src/renderer/src/hooks/useDetectedAgents.ts
+++ b/src/renderer/src/hooks/useDetectedAgents.ts
@@ -147,7 +147,8 @@ export function useDetectedAgents(
     const isNewRemoteTarget =
       remoteTargetKey !== null && !observedRemoteTargetKeysRef.current.has(remoteTargetKey)
     // Why: switching A → B → A is still one mounted surface; remember every
-    // target so empty hosts don't respawn all detection subprocesses on each switch.
+    // target so each one keeps its once-per-surface probe without respawning
+    // detection on every switch back.
     if (remoteTargetKey !== null) {
       observedRemoteTargetKeysRef.current.add(remoteTargetKey)
     }
@@ -155,18 +156,21 @@ export function useDetectedAgents(
     if (targetKind === 'ssh' && targetId) {
       if (detectedIds === null) {
         void state.ensureRemoteDetectedAgents(targetId)
-      } else if (detectedIds.length === 0 && isNewRemoteTarget) {
-        // Why: a newly opened remote launch surface should get one fresh probe
-        // after a prior empty result, but must not spin while the host has no agents.
-        void state.ensureRemoteDetectedAgents(targetId)
+      } else if (isNewRemoteTarget) {
+        // Why: a newly opened remote launch surface must re-probe even when it
+        // already has a cached list — otherwise a CLI installed after the last
+        // probe stays invisible until the renderer restarts. Once per surface,
+        // per target, so this cannot spin.
+        void state.ensureRemoteDetectedAgents(targetId, { force: true })
       }
     } else if (targetKind === 'runtime' && targetId) {
       if (detectedIds === null) {
         void state.ensureRuntimeDetectedAgents(targetId)
-      } else if (detectedIds.length === 0 && isNewRemoteTarget) {
-        // Why: remote `orca serve` users can install/fix PATH without reconnecting;
-        // retry once per mounted surface so the menu can pick that up.
-        void state.ensureRuntimeDetectedAgents(targetId)
+      } else if (isNewRemoteTarget) {
+        // Why: remote `orca serve` users can install/fix PATH without
+        // reconnecting; retry once per mounted surface so the menu can pick
+        // that up regardless of what the previous probe found.
+        void state.ensureRuntimeDetectedAgents(targetId, { force: true })
       }
     } else {
       if (detectedIds === null) {

--- a/src/renderer/src/store/slices/runtime-detected-agents.test.ts
+++ b/src/renderer/src/store/slices/runtime-detected-agents.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression: a runtime (`orca serve`) host that already reported agents must be
+ * re-probed when a new launch surface mounts. `ensureRuntimeDetectedAgents`
+ * short-circuits any non-empty cached list, so without the `force` escape hatch
+ * the mount-time retry in `useDetectedAgents` was a no-op and a CLI installed
+ * after the first detection stayed invisible until the Orca client restarted.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RuntimeRpcClientModule from '@/runtime/runtime-rpc-client'
+import type { AppState } from '../types'
+import { _getRuntimeDetectPromiseCountForTest } from './runtime-detected-agents'
+import { createTestStore } from './store-test-helpers'
+
+const runtimeRpc = vi.hoisted(() => ({ callRuntimeRpc: vi.fn() }))
+
+vi.mock('@/runtime/runtime-rpc-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RuntimeRpcClientModule>()
+  return { ...actual, callRuntimeRpc: runtimeRpc.callRuntimeRpc }
+})
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: {} }
+
+describe('ensureRuntimeDetectedAgents force', () => {
+  beforeEach(() => {
+    runtimeRpc.callRuntimeRpc.mockReset()
+  })
+
+  it('re-probes a cached non-empty list only when forced', async () => {
+    const store = createTestStore()
+    runtimeRpc.callRuntimeRpc.mockResolvedValueOnce(['claude'])
+
+    await expect(store.getState().ensureRuntimeDetectedAgents('env-1')).resolves.toEqual(['claude'])
+    expect(runtimeRpc.callRuntimeRpc).toHaveBeenCalledTimes(1)
+
+    // Unforced callers keep the cached list — store churn must not re-probe.
+    await expect(store.getState().ensureRuntimeDetectedAgents('env-1')).resolves.toEqual(['claude'])
+    expect(runtimeRpc.callRuntimeRpc).toHaveBeenCalledTimes(1)
+
+    // A freshly mounted launch surface forces one probe, so a CLI installed
+    // after the first detection appears without a client restart.
+    runtimeRpc.callRuntimeRpc.mockResolvedValueOnce(['claude', 'devin'])
+    await expect(
+      store.getState().ensureRuntimeDetectedAgents('env-1', { force: true })
+    ).resolves.toEqual(['claude', 'devin'])
+
+    expect(runtimeRpc.callRuntimeRpc).toHaveBeenCalledTimes(2)
+    expect(runtimeRpc.callRuntimeRpc).toHaveBeenLastCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'preflight.detectAgents'
+    )
+    expect(store.getState().runtimeDetectedAgentIds['env-1']).toEqual(['claude', 'devin'])
+  })
+
+  it('collapses concurrent forced mounts onto a single probe', async () => {
+    const store = createTestStore()
+    store.setState({ runtimeDetectedAgentIds: { 'env-1': ['claude'] } } as Partial<AppState>)
+
+    let resolveDetect: (value: unknown) => void = () => {}
+    runtimeRpc.callRuntimeRpc.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDetect = resolve
+        })
+    )
+
+    const first = store.getState().ensureRuntimeDetectedAgents('env-1', { force: true })
+    const second = store.getState().ensureRuntimeDetectedAgents('env-1', { force: true })
+
+    expect(_getRuntimeDetectPromiseCountForTest()).toBe(1)
+    expect(runtimeRpc.callRuntimeRpc).toHaveBeenCalledTimes(1)
+
+    resolveDetect(['claude', 'devin'])
+    await expect(first).resolves.toEqual(['claude', 'devin'])
+    await expect(second).resolves.toEqual(['claude', 'devin'])
+    expect(store.getState().runtimeDetectedAgentIds['env-1']).toEqual(['claude', 'devin'])
+  })
+
+  it('keeps the last known list when a forced probe fails', async () => {
+    const store = createTestStore()
+    store.setState({ runtimeDetectedAgentIds: { 'env-1': ['claude'] } } as Partial<AppState>)
+    runtimeRpc.callRuntimeRpc.mockRejectedValueOnce(new Error('runtime disconnected'))
+
+    await expect(
+      store.getState().ensureRuntimeDetectedAgents('env-1', { force: true })
+    ).resolves.toEqual([])
+
+    // Why: a transient failure on the mount-time probe must not empty the picker.
+    expect(store.getState().runtimeDetectedAgentIds['env-1']).toEqual(['claude'])
+    expect(store.getState().isDetectingRuntimeAgents['env-1']).toBe(false)
+  })
+})

--- a/src/renderer/src/store/slices/runtime-detected-agents.ts
+++ b/src/renderer/src/store/slices/runtime-detected-agents.ts
@@ -10,7 +10,10 @@ export type RuntimeDetectedAgentsSlice = {
   runtimeDetectedAgentIds: Record<string, TuiAgent[] | null>
   isDetectingRuntimeAgents: Record<string, boolean>
   isRefreshingRuntimeAgents: Record<string, boolean>
-  ensureRuntimeDetectedAgents: (environmentId: string) => Promise<TuiAgent[]>
+  ensureRuntimeDetectedAgents: (
+    environmentId: string,
+    options?: { force?: boolean }
+  ) => Promise<TuiAgent[]>
   /** Forces a re-detect on the runtime host via `preflight.refreshAgents`
    *  (login-shell PATH re-read), falling back to `preflight.detectAgents` for
    *  servers that predate the refresh RPC. */
@@ -45,7 +48,7 @@ export const createRuntimeDetectedAgentsSlice: StateCreator<
   isDetectingRuntimeAgents: {},
   isRefreshingRuntimeAgents: {},
 
-  ensureRuntimeDetectedAgents: (environmentId: string) => {
+  ensureRuntimeDetectedAgents: (environmentId: string, options?: { force?: boolean }) => {
     const inflightRefresh = runtimeRefreshPromises.get(environmentId)
     if (inflightRefresh) {
       return inflightRefresh
@@ -53,8 +56,10 @@ export const createRuntimeDetectedAgentsSlice: StateCreator<
     const existing = get().runtimeDetectedAgentIds[environmentId]
     // Why: an empty result ([]) is truthy, so a prior "no agents found" detection
     // must not be treated as cached — re-detect so a later install / PATH fix is
-    // picked up without a reconnect. Non-empty results still short-circuit.
-    if (existing?.length) {
+    // picked up without a reconnect. A non-empty result short-circuits unless the
+    // caller forces (a freshly mounted launch surface must re-probe, otherwise a
+    // CLI installed after the last probe stays invisible until the client quits).
+    if (existing?.length && options?.force !== true) {
       return Promise.resolve(existing)
     }
     const inflight = runtimeDetectPromises.get(environmentId)


### PR DESCRIPTION
## ELI5

If you install a coding-agent CLI on a remote host after Orca has already looked for agents there, Orca keeps showing the old list — quitting and reopening the app was the only way to see it. Now Orca looks again every time you open the picker (or any other launch surface) for that host, so a newly installed agent shows up right away.

## What Changed

- `useDetectedAgents`: the once-per-mounted-surface remote retry now runs for **any** cached result and passes `{ force: true }` so the probe actually happens. It was gated on `detectedIds.length === 0`, so a host with at least one detected agent never re-probed.
- `runtime-detected-agents` store slice: `ensureRuntimeDetectedAgents` accepts `options?: { force?: boolean }`, matching `ensureRemoteDetectedAgents` (SSH) and the local slice. Without that escape hatch a non-empty cached list short-circuited the forced call, so removing the hook gate on its own would have been a no-op.
- `ComposerIdentityModel.ensureRuntimeDetectedAgents` type updated for parity with the SSH entry above it.

## Why

The retry site's own comment describes the intended behaviour — "retry once per mounted surface so the menu can pick that up" — but two layers disagreed with it: the hook only asked when the previous result was empty, and the runtime store could not be forced even if it had asked. An agent installed after the first probe was therefore undetectable for the rest of the renderer session. The escape hatches that exist today do not cover it: `Settings → Agents → Refresh` re-probes only the *Active Server* (a different host in the reported setup), and for a non-active SSH host the hook's `refresh` has no UI caller at all.

The picker's menu items mount with the dropdown, so "reopen the picker" and "open a new tab" (a fresh tab bar / settings pane) are exactly the mounted-surface event this retry is written around.

### Cost and staleness tradeoff

- The mount-time probe uses the cheap path (`preflight.detectAgents`): on a paired runtime host PATH hydration is already cached process-wide and the checks are filesystem lookups (no subprocess per agent); on SSH it is a single relay request. The heavier `preflight.refreshAgents` (forced login-shell PATH re-read) is still only run by the explicit Refresh action.
- In-flight dedupe collapses concurrent mounts onto one probe, and `observedRemoteTargetKeysRef` keeps it once per surface per target, so re-renders and A → B → A switches do not loop (pinned by a test).
- Local (non-remote) detection is deliberately untouched: it has a working user-facing Refresh against the active server, and it is the path that owns the expensive WSL-distro probes.
- A failed mount-time probe keeps the last known list (pinned by a test), so a momentarily disconnected runtime cannot empty the picker.

### Not included

The issue's optional suggestion — a "Refresh agents" affordance in the quick-launch menu that refreshes the worktree's own target instead of the Active Server — is a separate UX change and is not part of this fix.

## Linked Issue

Fixes #20383

## Visual Proof

`N/A` — no rendered UI changed; the picker renders the same rows and this only changes *when* the host is re-probed. The user-visible difference (an agent installed after the first probe appears on the next picker open instead of after a client restart) is pinned by the before/after regression tests below. I did not run the desktop app against a paired remote host in this session, so this is verified at the hook/store level rather than by a manual app run.

## Testing

New tests fail against the unmodified hook/slice and pass with the fix (each was run before the source change to confirm it fails for the right reason):

`src/renderer/src/hooks/useDetectedAgents.test.tsx`
- ssh: re-probes a cached non-empty list when the launch surface is reopened
- ssh: keeps a non-empty target to one probe per mounted surface (no spin on re-render)
- runtime: re-probes a cached non-empty list when the launch surface is reopened
- runtime: a Refresh that clears the list settles without bouncing into another probe loop

`src/renderer/src/store/slices/runtime-detected-agents.test.ts` (new file)
- a forced call re-probes a cached non-empty list; unforced callers stay cached
- concurrent forced mounts collapse onto a single probe
- a failed forced probe keeps the last known list

Commands run locally (Linux):
- `pnpm test src/renderer/src/hooks src/renderer/src/store src/renderer/src/components/tab-bar src/renderer/src/components/settings src/renderer/src/components/dashboard` → 786 files / 6306 tests pass
- `pnpm lint` → clean (including the max-lines and code-quality ratchets)
- `pnpm tc:web` → clean
- `pnpm check:code-quality:changed` → clean

Full `pnpm test` reaches 73644 passing tests with the pre-existing environment failures that also fail on the base commit in the primary checkout (`workflow-ref-reachability`, `claude-structured-real-cli`, `wsl-hook-relay-live.integration`, `wsl-hook-relay-manager`, `hosted-review-bitbucket.integration` — real CLI / WSL host / network credentials are unavailable here). None of them touch the renderer agent-detection path.

Platforms: renderer-only change with no new platform branches. Remote paths are covered by the ssh and runtime cases; the local path is unchanged.

## Review

AI agent review of this diff:

- **Cross-platform**: renderer-only store/hook logic; no paths, shortcuts, or platform checks touched.
- **SSH / remote / local**: the fix is scoped to `ssh:` and `runtime:` targets. Remote wire compatibility is unaffected — `force` is a renderer-local cache bypass; the RPC (`preflight.detectAgents`, no params) and its payload are unchanged, and no new field or opcode crosses the wire. Local detection keeps its existing once-per-surface behaviour.
- **Agents / integrations**: no agent catalog, launch-command, or provider-specific code touched; the change only affects which hosts are re-probed and when.
- **Performance risk**: one extra detect per mounted surface, per host, deduped in flight. On the paired-runtime path it is filesystem path lookups against an already-hydrated PATH; on SSH it is one relay request. No new per-agent subprocess and no login-shell spawn.
- **UI quality**: no rendered surface changed; loading/refresh flag semantics are preserved (`detectionFailed` cannot flip while a cached list exists, and a forced probe keeps rendering the cached list).
- **Security**: no new inputs, IPC surface, or privilege boundaries; `force` only bypasses an in-renderer cache check.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Cross-platform**: no platform-specific behaviour added.
- **Remote SSH**: this is the path being fixed; covered above.
- **Mobile**: no mobile code touched (renderer store is Electron/web-client only).
- **Backwards compatibility**: no protocol or persisted-state change; the new option is optional, so existing callers are unaffected.
- **Performance**: covered above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Not checked locally in full: `pnpm lint`/`pnpm tc:web` pass and the affected suites pass, but the full `pnpm test` run only fails on the pre-existing environment-dependent tests listed above, and `pnpm build` was left to CI.
