### PR TITLE
fix(native-chat): pick the attachment form per agent

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -433,6 +433,32 @@ describe('NativeChatComposer', () => {
     expect(mocks.sendNativeChatMessageWithImageAttachments).toHaveBeenCalledWith(
       {},
       'pty-1',
+      'codex',
+      'hello',
+      ['/tmp/pasted.png'],
+      undefined
+    )
+  })
+
+  // The composer owns which agent the send path branches on; a dropped prop
+  // would silently give every agent the image-paste form again.
+  it('forwards the pane agent so the send path can pick the attachment form', () => {
+    mocks.imageAttachments = [{ id: 'image-1', path: '/tmp/pasted.png' }]
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="omp"
+      />
+    )
+
+    act(() => mocks.fieldProps?.onSend?.())
+
+    expect(mocks.sendNativeChatMessageWithImageAttachments).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      'omp',
       'hello',
       ['/tmp/pasted.png'],
       undefined

--- a/src/renderer/src/components/native-chat/native-chat-runtime-image-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-image-send.ts
@@ -1,9 +1,10 @@
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import type { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
-import { imagePasteWritesFollowedByText } from '../../../../shared/image-paste-following-text'
+import type { AgentType } from '../../../../shared/agent-status-types'
 import { NATIVE_CHAT_SUBMIT_DELAY_MS } from '../../../../shared/native-chat-answer-stepping'
+import { getNativeChatAttachmentForm } from '../../../../shared/native-chat-agent-profiles'
 import {
-  buildNativeChatImagePasteBytes,
+  buildNativeChatAttachmentWrites,
   buildNativeChatPasteBytes,
   NATIVE_CHAT_SUBMIT
 } from './native-chat-send'
@@ -21,9 +22,13 @@ export const NATIVE_CHAT_IMAGE_ATTACHMENT_SETTLE_MS = 300
 
 type RuntimeSettings = ReturnType<typeof getSettingsForAgentTabRuntimeOwner>
 
+/** `agent` picks the attachment form: only agents with a verified image-paste
+ *  gesture get a bracketed raw path; the rest get `@path` (see
+ *  getNativeChatAttachmentForm). */
 export function sendNativeChatMessageWithImageAttachments(
   settings: RuntimeSettings,
   ptyId: string,
+  agent: AgentType | null | undefined,
   text: string,
   imagePaths: readonly string[],
   options?: NativeChatSendOptions
@@ -47,8 +52,9 @@ export function sendNativeChatMessageWithImageAttachments(
         if (isCancelled()) {
           return
         }
-        for (const payload of imagePasteWritesFollowedByText(
-          imagePaths.map(buildNativeChatImagePasteBytes),
+        for (const payload of buildNativeChatAttachmentWrites(
+          imagePaths,
+          getNativeChatAttachmentForm(agent),
           trimmedText.length > 0
         )) {
           sendRuntimePtyInput(settings, ptyId, payload)

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send-launch-draft.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send-launch-draft.test.ts
@@ -161,7 +161,7 @@ describe('sendNativeChatMessage with a parked multi-line draft', () => {
 describe('image sends with a parked multi-line draft', () => {
   it('clears every draft line before pasting, so no line rides along with the image', () => {
     const clearInput = buildAgentTuiClearInputForText(DRAFT)
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'caption', ['/tmp/a.png'], {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'caption', ['/tmp/a.png'], {
       clearInput
     })
     expect(writes()[0]).toBe(clearInput)
@@ -169,7 +169,7 @@ describe('image sends with a parked multi-line draft', () => {
 
   it('clears exactly once — a second Ctrl+U would wipe the just-pasted image', () => {
     const clearInput = buildAgentTuiClearInputForText(DRAFT)
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'caption', ['/tmp/a.png'], {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'caption', ['/tmp/a.png'], {
       clearInput
     })
     vi.advanceTimersByTime(10_000)
@@ -178,7 +178,7 @@ describe('image sends with a parked multi-line draft', () => {
 
   it('submits the image send before a queued message starts', async () => {
     const clearInput = buildAgentTuiClearInputForText(DRAFT)
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'caption', ['/tmp/a.png'], {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'caption', ['/tmp/a.png'], {
       clearInput,
       confirmCleared: () => true
     })

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
@@ -327,9 +327,13 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('clears the line, then bracket-pastes image paths before prompt text', () => {
-    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'what do you see?', [
-      '/tmp/orca-paste-image.png'
-    ])
+    const handle = sendNativeChatMessageWithImageAttachments(
+      SETTINGS,
+      PTY,
+      'claude',
+      'what do you see?',
+      ['/tmp/orca-paste-image.png']
+    )
 
     expect(handle.settleAfterMs).toBe(
       NATIVE_CHAT_IMAGE_ATTACHMENT_SETTLE_MS + NATIVE_CHAT_SUBMIT_DELAY_MS
@@ -350,7 +354,7 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('does not append a trailing separator on an attachment-only send', () => {
-    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, '', [
+    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', '', [
       '/tmp/orca-paste-image.png'
     ])
 
@@ -370,7 +374,9 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('treats whitespace-only prompt input as attachment-only', () => {
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, '   ', ['/tmp/orca-paste-image.png'])
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', '   ', [
+      '/tmp/orca-paste-image.png'
+    ])
 
     expectWriteOrder(sendRuntimePtyInput.mock.calls, [
       NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
@@ -378,8 +384,24 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
     ])
   })
 
+  it('sends an @path reference, not a bracketed frame, to an agent with no image paste', () => {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'omp', 'hello', [
+      '/tmp/a.png',
+      '/tmp/b.png'
+    ])
+
+    expectWriteOrder(sendRuntimePtyInput.mock.calls, [
+      NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
+      '@/tmp/a.png ',
+      '@/tmp/b.png '
+    ])
+  })
+
   it('keeps multiple image frames bare and separates only the final frame from prompt text', () => {
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'hello', ['/tmp/a.png', '/tmp/b.png'])
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'hello', [
+      '/tmp/a.png',
+      '/tmp/b.png'
+    ])
 
     expectWriteOrder(sendRuntimePtyInput.mock.calls, [
       NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
@@ -389,7 +411,7 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('cancels deferred prompt and Enter writes after the attachment path', () => {
-    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'describe', [
+    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'describe', [
       '/tmp/orca-paste-image.png'
     ])
     handle.cancel()

--- a/src/renderer/src/components/native-chat/native-chat-send.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import { NATIVE_CHAT_SUPPORTED_AGENT_LIST } from '../../../../shared/native-chat-agent-support'
+import { getNativeChatAttachmentForm } from '../../../../shared/native-chat-agent-profiles'
+import { getAgentImageHandling } from './native-chat-image-paste'
 import {
-  buildNativeChatImagePasteBytes,
+  buildNativeChatAttachmentBytes,
+  buildNativeChatAttachmentWrites,
   buildNativeChatPasteBytes,
   buildNativeChatSendBytes,
   isMultilineDraft,
@@ -46,17 +50,94 @@ describe('buildNativeChatPasteBytes', () => {
   })
 })
 
-describe('buildNativeChatImagePasteBytes', () => {
-  it('always bracket-pastes the image path so agent TUIs attach it as an image', () => {
-    expect(buildNativeChatImagePasteBytes('/tmp/orca-paste-image.png')).toBe(
+describe('buildNativeChatAttachmentBytes', () => {
+  it('bracket-pastes the image path for agents that attach a pasted path', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/orca-paste-image.png', 'image-paste')).toBe(
       `${BEGIN}/tmp/orca-paste-image.png${END}`
     )
   })
 
   it('sanitizes embedded escape bytes before framing', () => {
-    expect(buildNativeChatImagePasteBytes('/tmp/before\x1b[201~after.png')).toBe(
+    expect(buildNativeChatAttachmentBytes('/tmp/before\x1b[201~after.png', 'image-paste')).toBe(
       `${BEGIN}/tmp/before␛[201~after.png${END}`
     )
+  })
+
+  it('sends an unframed @path for agents with no image-paste gesture', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/orca-paste-image.png', 'file-reference')).toBe(
+      '@/tmp/orca-paste-image.png'
+    )
+  })
+
+  it('quotes a spaced path and sanitizes escape bytes in the reference form', () => {
+    expect(buildNativeChatAttachmentBytes('C:\\My Shots\\a.png', 'file-reference')).toBe(
+      '@"C:\\My Shots\\a.png"'
+    )
+    expect(buildNativeChatAttachmentBytes('/tmp/a\x1b[201~b.png', 'file-reference')).toBe(
+      '@/tmp/a␛[201~b.png'
+    )
+  })
+
+  // An unframed write is keystrokes: a CR in a filename would submit the turn.
+  it('frames a reference whose path carries a line break instead of writing a bare CR', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/a\nb.png', 'file-reference')).toBe(
+      `${BEGIN}@"/tmp/a\rb.png"${END}`
+    )
+    expect(buildNativeChatAttachmentBytes('/tmp/a\rb.png', 'file-reference')).toBe(
+      `${BEGIN}@"/tmp/a\rb.png"${END}`
+    )
+  })
+
+  // The A1 regression: two Native-Chat agents must not share one attachment form.
+  it('emits a different form for an unverified agent than for Claude', () => {
+    const path = '/tmp/shot.png'
+    expect(buildNativeChatAttachmentBytes(path, getNativeChatAttachmentForm('claude'))).not.toBe(
+      buildNativeChatAttachmentBytes(path, getNativeChatAttachmentForm('omp'))
+    )
+  })
+
+  // Expected bytes are literal, not derived from the function under test, so a
+  // table flip that made every agent agree would fail here.
+  it.each([
+    ['claude', `${BEGIN}/tmp/shot.png${END}`],
+    ['openclaude', `${BEGIN}/tmp/shot.png${END}`],
+    ['codex', `${BEGIN}/tmp/shot.png${END}`],
+    ['grok', `${BEGIN}/tmp/shot.png${END}`],
+    ['omp', '@/tmp/shot.png']
+  ] as const)('%s attaches /tmp/shot.png as %s', (agent, expected) => {
+    expect(
+      buildNativeChatAttachmentBytes('/tmp/shot.png', getNativeChatAttachmentForm(agent))
+    ).toBe(expected)
+  })
+
+  it('covers every native-chat agent in the table above', () => {
+    expect([...NATIVE_CHAT_SUPPORTED_AGENT_LIST].sort()).toEqual(
+      ['claude', 'codex', 'grok', 'omp', 'openclaude'].sort()
+    )
+  })
+})
+
+describe('buildNativeChatAttachmentWrites', () => {
+  it('leaves back-to-back image frames bare and separates only the last from text', () => {
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'image-paste', true)
+    ).toEqual([`${BEGIN}/tmp/a.png${END}`, `${BEGIN}/tmp/b.png${END} `])
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'image-paste', false)
+    ).toEqual([`${BEGIN}/tmp/a.png${END}`, `${BEGIN}/tmp/b.png${END}`])
+  })
+
+  it('separates every @path reference, which is not self-delimiting', () => {
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'file-reference', true)
+    ).toEqual(['@/tmp/a.png ', '@/tmp/b.png '])
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'file-reference', false)
+    ).toEqual(['@/tmp/a.png ', '@/tmp/b.png'])
+  })
+
+  it('writes nothing when there are no attachments', () => {
+    expect(buildNativeChatAttachmentWrites([], 'file-reference', true)).toEqual([])
   })
 })
 
@@ -104,5 +185,17 @@ describe('isMultilineDraft', () => {
   })
   it('is true when a newline is present', () => {
     expect(isMultilineDraft('a\nb')).toBe(true)
+  })
+})
+
+// Two per-agent tables answer "does this agent attach a pasted path?": the send
+// side's attachmentForm and the clipboard side's IMAGE_ATTACHMENT_AGENTS. They
+// must agree, or a drop and a paste of the same image reach the agent differently.
+describe('attachment form agrees with clipboard image handling', () => {
+  it.each(NATIVE_CHAT_SUPPORTED_AGENT_LIST)('%s', (agent) => {
+    const acceptsPastedPath = getAgentImageHandling(agent) === 'attachment'
+    expect(getNativeChatAttachmentForm(agent)).toBe(
+      acceptsPastedPath ? 'image-paste' : 'file-reference'
+    )
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.ts
@@ -1,10 +1,16 @@
 // Pure: turn raw composer text into the exact PTY bytes to write. Kept separate
 // from the React composer so the byte rules are unit-testable without a DOM.
 
+import type { NativeChatAttachmentForm } from '../../../../shared/native-chat-agent-profiles'
+import {
+  imagePasteWritesFollowedByText,
+  separateImagePasteFromFollowingText
+} from '../../../../shared/image-paste-following-text'
 import {
   sanitizeBracketedPasteText,
   wrapTerminalBracketedPasteText
 } from '../terminal-pane/terminal-bracketed-paste'
+import { formatNativeChatFileReference } from './native-chat-composer-target'
 
 // Why: carriage return (not \n) is what xterm/agent composers treat as the
 // submit/Enter key over a PTY.
@@ -40,10 +46,41 @@ export function buildNativeChatPasteBytes(text: string): string {
   return sanitizeBracketedPasteText(text)
 }
 
-/** Image attachments must look like a real terminal image paste to Claude/Codex
- *  TUIs. A plain typed path (or @file mention) is treated as text/file-read. */
-export function buildNativeChatImagePasteBytes(filePath: string): string {
+/**
+ * One attachment's bytes, in the form its agent understands:
+ *  - `image-paste` → bracketed paste of the raw path. Claude/Codex/Grok TUIs
+ *    detect that gesture and attach the file as an image; a plain typed path (or
+ *    @file mention) would be treated as text/file-read instead.
+ *  - `file-reference` → the portable `@path` mention. Agents with no verified
+ *    image-paste gesture would otherwise receive a naked path as prose.
+ */
+export function buildNativeChatAttachmentBytes(
+  filePath: string,
+  form: NativeChatAttachmentForm
+): string {
+  if (form === 'file-reference') {
+    // Why: an unframed write is keystrokes, so a filename holding CR/LF would
+    // submit the turn early. buildNativeChatPasteBytes already frames those.
+    return buildNativeChatPasteBytes(formatNativeChatFileReference(filePath))
+  }
   return wrapTerminalBracketedPasteText(filePath)
+}
+
+/** The per-attachment PTY writes for a send. Bracketed image frames are
+ *  self-delimiting, so only the last needs a space before prompt text; `@path`
+ *  references are plain text and need one between every pair as well. */
+export function buildNativeChatAttachmentWrites(
+  filePaths: readonly string[],
+  form: NativeChatAttachmentForm,
+  followedByText: boolean
+): string[] {
+  const payloads = filePaths.map((filePath) => buildNativeChatAttachmentBytes(filePath, form))
+  if (form === 'image-paste') {
+    return imagePasteWritesFollowedByText(payloads, followedByText)
+  }
+  return payloads.map((payload, index) =>
+    separateImagePasteFromFollowingText(payload, index < payloads.length - 1 || followedByText)
+  )
 }
 
 /**

--- a/src/renderer/src/components/native-chat/use-native-chat-pty-composer-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pty-composer-send.ts
@@ -74,6 +74,7 @@ export function useNativeChatPtyComposerSend(args: {
       pendingHandle = sendNativeChatMessageWithImageAttachments(
         target.settings,
         target.ptyId,
+        args.agent,
         text,
         imagePaths,
         sendOptions

--- a/src/shared/native-chat-agent-profiles.test.ts
+++ b/src/shared/native-chat-agent-profiles.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { NATIVE_CHAT_SUPPORTED_AGENT_LIST } from './native-chat-agent-support'
 import {
   getHostClaimedNativeChatCommands,
   getNativeChatAgentProfile,
+  getNativeChatAttachmentForm,
   getVerifiedNativeChatCommands
 } from './native-chat-agent-profiles'
 
@@ -54,5 +56,35 @@ describe('host-claimed native chat commands', () => {
   it('claims the whole catalog for agents with no pass-through policy', () => {
     expect(names('custom-agent')).toEqual(['clear', 'help'])
     expect(names('grok')).toEqual([])
+  })
+})
+
+describe('native chat attachment form', () => {
+  it.each([
+    ['claude', 'image-paste'],
+    ['openclaude', 'image-paste'],
+    ['codex', 'image-paste'],
+    ['grok', 'image-paste'],
+    // OMP wraps Pi's TUI, which has no verified image-path paste gesture.
+    ['omp', 'file-reference'],
+    ['custom-agent', 'file-reference']
+  ] as const)('%s attaches as %s', (agent, form) => {
+    expect(getNativeChatAttachmentForm(agent)).toBe(form)
+  })
+
+  it('never leaves a native-chat agent without a form', () => {
+    for (const agent of NATIVE_CHAT_SUPPORTED_AGENT_LIST) {
+      expect(getNativeChatAttachmentForm(agent)).toMatch(/^(image-paste|file-reference)$/)
+    }
+  })
+
+  it('does not give every native-chat agent the same form', () => {
+    const forms = new Set(NATIVE_CHAT_SUPPORTED_AGENT_LIST.map(getNativeChatAttachmentForm))
+    expect(forms.size).toBeGreaterThan(1)
+  })
+
+  it('falls back to the reference form for an unknown agent', () => {
+    expect(getNativeChatAttachmentForm(null)).toBe('file-reference')
+    expect(getNativeChatAttachmentForm(undefined)).toBe('file-reference')
   })
 })

--- a/src/shared/native-chat-agent-profiles.ts
+++ b/src/shared/native-chat-agent-profiles.ts
@@ -1,6 +1,12 @@
 import type { AgentType } from './agent-status-types'
 import { getAgentSlashCommands, type SlashCommandSuggestion } from './native-chat-slash-commands'
 
+/** How an agent takes a composer attachment. `image-paste` bracket-pastes the
+ *  raw path, which only agents with a verified image-paste gesture turn into an
+ *  attachment chip; `file-reference` sends the portable `@path` mention, which
+ *  every other agent reads as a file to open rather than as prose. */
+export type NativeChatAttachmentForm = 'image-paste' | 'file-reference'
+
 export type NativeChatAgentProfile = {
   skillPrefix: '$' | '/'
   /** OpenClaude reads Claude-owned roots, so this can differ from the agent. */
@@ -11,6 +17,7 @@ export type NativeChatAgentProfile = {
   /** Catalog commands the model acts on when they arrive as prose, even though
    *  the runtime has no slash parser of its own. */
   textDrivenCommands?: readonly string[]
+  attachmentForm: NativeChatAttachmentForm
 }
 
 const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfile>> = {
@@ -19,21 +26,25 @@ const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfi
     skillSourceOwner: 'codex',
     // The app-server has no slash parser, but the model owns goal tools and
     // calls create_goal itself when `/goal <objective>` reaches it as prose.
-    textDrivenCommands: ['goal']
+    textDrivenCommands: ['goal'],
+    attachmentForm: 'image-paste'
   },
   claude: {
     skillPrefix: '/',
     skillSourceOwner: 'claude',
-    expandsSlashCommandsFromText: true
+    expandsSlashCommandsFromText: true,
+    attachmentForm: 'image-paste'
   },
   openclaude: {
     skillPrefix: '/',
     skillSourceOwner: 'claude',
-    expandsSlashCommandsFromText: true
+    expandsSlashCommandsFromText: true,
+    attachmentForm: 'image-paste'
   },
   grok: {
     skillPrefix: '/',
-    skillSourceOwner: 'grok'
+    skillSourceOwner: 'grok',
+    attachmentForm: 'image-paste'
   }
 }
 
@@ -41,6 +52,15 @@ export function getNativeChatAgentProfile(
   agent: AgentType | null | undefined
 ): NativeChatAgentProfile | null {
   return agent ? (NATIVE_CHAT_AGENT_PROFILES[agent] ?? null) : null
+}
+
+/** Attachment form for an agent. Agents without a verified profile fall back to
+ *  `@path`: an unverified TUI has no image-paste gesture, so a bracketed raw
+ *  path would land in its composer as text the model reads as prose. */
+export function getNativeChatAttachmentForm(
+  agent: AgentType | null | undefined
+): NativeChatAttachmentForm {
+  return getNativeChatAgentProfile(agent)?.attachmentForm ?? 'file-reference'
 }
 
 /** The catalog that send classification, collision detection, and transcript


### PR DESCRIPTION
## ELI5

Native Chat sends an image to an agent by pasting the file's path into its terminal. Some agents see that paste as an image attachment, others only see text — and for agents without a verified image-paste gesture the path arrived as a bare mention the model read as prose. This makes Orca pick the form each agent actually accepts.

## What Changed

- Adds `attachmentForm` (`'image-paste' | 'file-reference'`) to the existing per-agent Native Chat profile table in `src/shared/native-chat-agent-profiles.ts`, rather than introducing a second mapping.
- Branches the attachment byte builder on it: agents with a verified gesture keep the bracketed raw-path paste, agents without one get the portable `@path` reference. A reference is framed when the name would otherwise be interpreted as keystrokes (CR/LF would submit the turn early).
- Threads the agent through the one existing PTY image-send path (`native-chat-runtime-image-send.ts`, `use-native-chat-pty-composer-send.ts`).
- Table-driven tests assert the two forms differ: `claude` emits a bracketed frame where `omp` emits `@path`.

## Why

Native Chat reaches exactly `claude`, `openclaude`, `codex`, `grok` and `omp` (`src/shared/native-chat-agent-support.ts`). `omp` is the one with no verified image-paste gesture — absent from `IMAGE_ATTACHMENT_AGENTS`, because it wraps Pi's TUI (`src/shared/tui-agent-config.ts`).

The clipboard route already refused `omp`, but the **drop and file-picker routes never consulted the agent**, so a dropped image reached it as a naked path. Branching on the existing profile table fixes all of them without a new pipeline.

## Linked Issue

Fixes #20389

## Visual Proof

N/A — this changes the PTY bytes written for an attachment, not any rendered UI. There is no visual or interaction change; what changes is which form an agent receives.

## Testing

- `pnpm test` on the native-chat, shared and terminal-pane suites touched here.
- `pnpm tc:web`, `pnpm tc:node`, `pnpm run check:code-quality:changed`.
- Platform notes: the change is platform-neutral byte construction — no new path handling, shortcuts, or platform branches. Not manually exercised on each OS for that reason.
- Review: a six-reviewer pass (correctness, project standards, testing, maintainability, frontend-races, plus an independent cross-model adversarial review) found one real defect in this change — an unframed `@path` write let a CR/LF filename submit the turn early — which is fixed here and pinned with a regression test.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Opus 5), running as an Orca-supervised worker. Reviewed by the multi-reviewer pass described above, and independently verified by the coordinating agent, which re-ran the test and typecheck gates against this exact tree.

## Review

Table-driven coverage per agent for the emitted bytes, plus a regression test for the CR/LF framing case. The `@path` fallback keeps the existing sanitisation so a pasted escape cannot reach the composer.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: byte construction only; no new IPC surface, no new dependency, no credential or path-ownership change.
- Cross-platform: no path or shortcut handling added; identical construction on macOS, Linux and Windows.
- SSH/remote: the send path is the existing one, so remote and local behaviour stay identical.
- Mobile: parity is handled in a stacked PR (#20391), which reuses these builders rather than adding a third table.
- Backwards compatibility: plain terminals keep their existing shell-escaped path behaviour.
- Performance: one extra profile lookup per attachment; write count per send is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
