### PR TITLE
fix(mobile-native-chat): pick the attachment form per agent

### DIFF
--- a/mobile/src/session/mobile-clipboard-image.test.ts
+++ b/mobile/src/session/mobile-clipboard-image.test.ts
@@ -152,6 +152,9 @@ describe('mobile clipboard image paste helpers', () => {
   it('brackets generated image paths before sending to the terminal', () => {
     expect(buildMobileImagePastePayload('/tmp/orca.png')).toBe('\x1b[200~/tmp/orca.png\x1b[201~')
     expect(buildMobileImagePastePayload('/tmp/\x1b.png')).toBe('\x1b[200~/tmp/\u241b.png\x1b[201~')
+    // Shares desktop's framer, so a newline in a path is normalized to CR inside
+    // the frame rather than reaching the PTY as a raw LF.
+    expect(buildMobileImagePastePayload('/tmp/a\nb.png')).toBe('\x1b[200~/tmp/a\rb.png\x1b[201~')
   })
 })
 

--- a/mobile/src/session/mobile-clipboard-image.ts
+++ b/mobile/src/session/mobile-clipboard-image.ts
@@ -1,3 +1,4 @@
+import { wrapTerminalBracketedPasteText } from '../../../src/shared/bracketed-paste-text'
 import type { RpcClient } from '../transport/rpc-client'
 import { isLogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import type { RpcFailure, RpcSuccess } from '../transport/types'
@@ -178,5 +179,5 @@ export function buildMobileImagePastePayload(filePath: string): string {
   // Why: generated image paths are paste payloads, not ordinary typed input.
   // Bracket the path even when it is one line so agents receive it atomically
   // and stale terminal paste state cannot turn it into shell commands.
-  return `\x1b[200~${filePath.split('\x1b').join('\u241b')}\x1b[201~`
+  return wrapTerminalBracketedPasteText(filePath)
 }

--- a/mobile/src/session/mobile-native-chat-controller-contract.ts
+++ b/mobile/src/session/mobile-native-chat-controller-contract.ts
@@ -23,6 +23,8 @@ export type MobileNativeChatController = {
   showNativeChatRef: MutableRefObject<boolean>
   /** Resolved agent for the active chat tab (names the empty-state copy). */
   nativeChatAgent: string | null
+  /** Same agent, read at send time — the active tab can change mid-send. */
+  nativeChatAgentRef: MutableRefObject<string | null>
   chatComposerText: string
   setChatComposerText: Dispatch<SetStateAction<string>>
   getChatComposerEditGeneration: () => number

--- a/mobile/src/session/mobile-native-chat-image-send.test.ts
+++ b/mobile/src/session/mobile-native-chat-image-send.test.ts
@@ -3,6 +3,8 @@ import type { RpcClient } from '../transport/rpc-client'
 import type { RpcResponse, RpcSuccess } from '../transport/types'
 import { pasteMobileNativeChatImagePaths } from './mobile-native-chat-image-send'
 import { buildAgentTuiClearInputForText } from '../../../src/shared/agent-tui-input-clear'
+import { NATIVE_CHAT_SUPPORTED_AGENT_LIST } from '../../../src/shared/native-chat-agent-support'
+import { getNativeChatAttachmentForm } from '../../../src/shared/native-chat-agent-profiles'
 
 function sendResult(accepted: boolean, id = 'send'): RpcSuccess {
   return { id, ok: true, result: { send: { accepted } }, _meta: { runtimeId: 'r' } }
@@ -38,6 +40,7 @@ describe('pasteMobileNativeChatImagePaths', () => {
       client,
       terminal: 'term-1',
       deviceToken: 'device-9',
+      agent: 'claude',
       imagePaths: ['/tmp/a.png', '/tmp/b.png', '/tmp/c.png'],
       followedByText: true
     })
@@ -67,6 +70,7 @@ describe('pasteMobileNativeChatImagePaths', () => {
       client,
       terminal: 'term-1',
       deviceToken: null,
+      agent: 'claude',
       imagePaths: ['/tmp/a.png', '/tmp/b.png'],
       followedByText: true
     })
@@ -96,6 +100,7 @@ describe('pasteMobileNativeChatImagePaths', () => {
         client,
         terminal: 'term-1',
         deviceToken: null,
+        agent: 'claude',
         imagePaths: ['/tmp/a.png', '/tmp/b.png'],
         followedByText: true
       })
@@ -123,6 +128,7 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       client,
       terminal: 'term-1',
       deviceToken: null,
+      agent: 'claude',
       imagePaths: ['/tmp/a.png'],
       followedByText: true,
       clearInput
@@ -140,6 +146,7 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       client,
       terminal: 'term-1',
       deviceToken: null,
+      agent: 'claude',
       imagePaths: ['/tmp/a.png', '/tmp/b.png'],
       followedByText: true,
       clearInput
@@ -156,6 +163,7 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       client,
       terminal: 'term-1',
       deviceToken: null,
+      agent: 'claude',
       imagePaths: ['/tmp/a.png'],
       followedByText: true
     })
@@ -170,6 +178,7 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       client,
       terminal: 'term-1',
       deviceToken: null,
+      agent: 'claude',
       imagePaths: ['/tmp/a.png', '/tmp/b.png'],
       followedByText: false
     })
@@ -178,5 +187,70 @@ describe('clearing a parked multi-line launch draft before the image paste', () 
       '\x1b[200~/tmp/a.png\x1b[201~',
       '\x1b[200~/tmp/b.png\x1b[201~'
     ])
+  })
+})
+
+describe('the attachment form mobile writes per agent', () => {
+  async function writesFor(agent: string | null, imagePaths: string[]): Promise<string[]> {
+    const client = clientWithResponses(
+      imagePaths.map(() => sendResult(true)).concat(sendResult(true))
+    )
+    const ok = await pasteMobileNativeChatImagePaths({
+      client,
+      terminal: 'term-1',
+      deviceToken: null,
+      agent,
+      imagePaths,
+      followedByText: true
+    })
+    expect(ok).toBe(true)
+    // Drop the leading clear; only the attachment writes are under test.
+    return client.calls.slice(1).map((call) => String(call.params.text))
+  }
+
+  it.each([
+    ['claude', 'image-paste'],
+    ['codex', 'image-paste'],
+    ['grok', 'image-paste'],
+    // OMP wraps Pi's TUI, which has no verified image-path paste gesture.
+    ['omp', 'file-reference'],
+    ['some-custom-agent', 'file-reference'],
+    [null, 'file-reference']
+  ] as const)('sends %s the %s form', async (agent, form) => {
+    const writes = await writesFor(agent, ['/tmp/a.png'])
+    expect(writes).toEqual(
+      form === 'image-paste' ? ['\x1b[200~/tmp/a.png\x1b[201~ '] : ['@/tmp/a.png ']
+    )
+  })
+
+  it('separates every @path reference, since a reference is not self-delimiting', async () => {
+    expect(await writesFor('omp', ['/tmp/a.png', '/tmp/b.png'])).toEqual([
+      '@/tmp/a.png ',
+      '@/tmp/b.png '
+    ])
+    // The bracketed frame closes itself, so only the last write needs the space.
+    expect(await writesFor('claude', ['/tmp/a.png', '/tmp/b.png'])).toEqual([
+      '\x1b[200~/tmp/a.png\x1b[201~',
+      '\x1b[200~/tmp/b.png\x1b[201~ '
+    ])
+  })
+
+  it('frames a CR/LF filename so a reference cannot submit the turn early', async () => {
+    const [write] = await writesFor('omp', ['/tmp/a\nb.png'])
+    expect(write).toBe('\x1b[200~@"/tmp/a\rb.png"\x1b[201~ ')
+    expect(write?.startsWith('\x1b[200~')).toBe(true)
+  })
+
+  it('quotes a spaced path so the reference stays one token', async () => {
+    expect(await writesFor('omp', ['/tmp/my shot.png'])).toEqual(['@"/tmp/my shot.png" '])
+  })
+
+  it('agrees with the shared per-agent rule for every native-chat agent', async () => {
+    for (const agent of NATIVE_CHAT_SUPPORTED_AGENT_LIST) {
+      const [write] = await writesFor(agent, ['/tmp/a.png'])
+      expect(write?.startsWith('\x1b[200~')).toBe(
+        getNativeChatAttachmentForm(agent) === 'image-paste'
+      )
+    }
   })
 })

--- a/mobile/src/session/mobile-native-chat-image-send.ts
+++ b/mobile/src/session/mobile-native-chat-image-send.ts
@@ -1,6 +1,6 @@
 import type { RpcClient } from '../transport/rpc-client'
-import { imagePasteWritesFollowedByText } from '../../../src/shared/image-paste-following-text'
-import { buildMobileImagePastePayload } from './mobile-clipboard-image'
+import { getNativeChatAttachmentForm } from '../../../src/shared/native-chat-agent-profiles'
+import { buildNativeChatAttachmentWrites } from '../../../src/shared/native-chat-paste-bytes'
 import {
   MOBILE_NATIVE_CHAT_MIN_WRITE_TIMEOUT_MS,
   openMobileNativeChatSendBudget
@@ -24,6 +24,9 @@ type PasteImagesArgs = {
   readonly terminal: string
   readonly deviceToken: string | null
   readonly imagePaths: readonly string[]
+  /** Picks the attachment form: only agents with a verified image-paste gesture
+   *  get a bracketed raw path, the rest get `@path` (getNativeChatAttachmentForm). */
+  readonly agent: string | null | undefined
   readonly followedByText: boolean
   /** Budget shared with the rest of the user action (the text body that follows, or
    *  the send this is healing for). Omit to open a fresh one for this paste alone. */
@@ -34,9 +37,9 @@ type PasteImagesArgs = {
   readonly clearInput?: string
 }
 
-/** Clears the agent's unsubmitted input line, then pastes each uploaded image
- *  path into the terminal as a bracketed paste (no Enter) — the same payload
- *  desktop native chat rides along on submit. The leading clear keeps a retry
+/** Clears the agent's unsubmitted input line, then writes each uploaded image
+ *  path into the terminal in the form `agent` understands (no Enter) — the same
+ *  payloads desktop native chat rides along on submit. The leading clear keeps a retry
  *  idempotent after a failed body/Enter. Returns false as soon as the host rejects
  *  one, so the caller can abort before Enter. */
 export async function pasteMobileNativeChatImagePaths({
@@ -44,6 +47,7 @@ export async function pasteMobileNativeChatImagePaths({
   terminal,
   deviceToken,
   imagePaths,
+  agent,
   followedByText,
   deadline: sharedDeadline,
   clearInput
@@ -58,7 +62,11 @@ export async function pasteMobileNativeChatImagePaths({
   const deadline = sharedDeadline ?? openMobileNativeChatSendBudget()
   for (const text of [
     clearInput ?? MOBILE_NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
-    ...imagePasteWritesFollowedByText(imagePaths.map(buildMobileImagePastePayload), followedByText)
+    ...buildNativeChatAttachmentWrites(
+      imagePaths,
+      getNativeChatAttachmentForm(agent),
+      followedByText
+    )
   ]) {
     const remainingMs = deadline - Date.now()
     // Why: the budget is the whole sequence's — starting a write it can't fund would

--- a/mobile/src/session/mobile-native-chat-stale-input.ts
+++ b/mobile/src/session/mobile-native-chat-stale-input.ts
@@ -55,6 +55,8 @@ export async function healMobileNativeChatStaleInput(args: {
       terminal: args.terminal,
       deviceToken: args.deviceToken,
       imagePaths: [],
+      // No attachment writes to shape — the heal is the leading clear alone.
+      agent: null,
       followedByText: false,
       ...(args.deadline === undefined ? {} : { deadline: args.deadline })
     })

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -264,6 +264,7 @@ export function useMobileNativeChatController(args: {
     showNativeChat,
     showNativeChatRef,
     nativeChatAgent: activeChatResolution?.agent ?? null,
+    nativeChatAgentRef: activeChatAgentRef,
     chatComposerText,
     setChatComposerText,
     getChatComposerEditGeneration,

--- a/mobile/src/session/use-mobile-native-chat-image-attachments-form.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments-form.test.ts
@@ -1,0 +1,119 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse, RpcSuccess } from '../transport/types'
+import { resetMobileNativeChatStaleInputForTests } from './mobile-native-chat-stale-input'
+import { resetMobileNativeChatTerminalWritesForTests } from './mobile-native-chat-terminal-write-lock'
+import { useMobileNativeChatImageAttachments } from './use-mobile-native-chat-image-attachments'
+
+// Fully stub the picker so the real expo/react-native chain never loads under
+// the vitest transform (react-native ships Flow syntax rolldown can't parse).
+vi.mock('./mobile-image-source-picker', () => ({
+  pickMobileImages: vi.fn(),
+  ImageLibraryPermissionError: class ImageLibraryPermissionError extends Error {}
+}))
+
+import { pickMobileImages } from './mobile-image-source-picker'
+
+const pick = vi.mocked(pickMobileImages)
+
+function ok(id: string, result: unknown): RpcSuccess {
+  return { id, ok: true, result, _meta: { runtimeId: 'r' } }
+}
+function methodNotFound(id: string): RpcResponse {
+  return {
+    id,
+    ok: false,
+    error: { code: 'method_not_found', message: 'no' },
+    _meta: { runtimeId: 'r' }
+  }
+}
+function sendResult(): RpcSuccess {
+  return { id: 'send', ok: true, result: { send: { accepted: true } }, _meta: { runtimeId: 'r' } }
+}
+
+function makeClient(responses: RpcResponse[]): Pick<RpcClient, 'sendRequest'> & {
+  calls: { method: string; params: Record<string, unknown> }[]
+} {
+  const calls: { method: string; params: Record<string, unknown> }[] = []
+  return {
+    calls,
+    sendRequest: vi.fn(async (method: string, params?: unknown) => {
+      calls.push({ method, params: params as Record<string, unknown> })
+      const response = responses.shift()
+      if (!response) {
+        throw new Error(`unexpected request: ${method}`)
+      }
+      return response
+    })
+  }
+}
+
+type HookArgs = Parameters<typeof useMobileNativeChatImageAttachments>[0]
+type Hook = ReturnType<typeof useMobileNativeChatImageAttachments>
+
+describe('the attachment form the native chat composer writes', () => {
+  let renderer: ReactTestRenderer | null = null
+  let hook: Hook | null = null
+
+  function Harness({ args }: { args: HookArgs }): null {
+    hook = useMobileNativeChatImageAttachments(args)
+    return null
+  }
+
+  beforeEach(() => {
+    pick.mockReset()
+    resetMobileNativeChatStaleInputForTests()
+    resetMobileNativeChatTerminalWritesForTests()
+  })
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    hook = null
+  })
+
+  it.each([
+    ['claude', '\x1b[200~/tmp/a.png\x1b[201~ '],
+    // OMP wraps Pi's TUI: no verified image-paste gesture, so it gets `@path`.
+    ['omp', '@/tmp/a.png ']
+  ])('writes the %s form for the agent on the tab it is sending to', async (agent, expected) => {
+    pick.mockResolvedValue([{ base64: 'AAAA', uri: 'file:///a.jpg' }])
+    const client = makeClient([
+      methodNotFound('start'),
+      ok('save', '/tmp/a.png'),
+      sendResult(), // Ctrl+U clear
+      sendResult() // the attachment write
+    ])
+    const args: HookArgs = {
+      client: client as unknown as RpcClient,
+      activeHandleRef: { current: 'term-1' },
+      agentRef: { current: agent },
+      deviceTokenRef: { current: null },
+      getActiveWorktreeConnectionId: async () => null,
+      connState: 'connected',
+      scopeKey: 'h\0w\0tab-a',
+      enabled: true,
+      showToast: vi.fn(),
+      onSendError: vi.fn(),
+      baseSend: vi.fn().mockResolvedValue('accepted'),
+      // The terminal paste path under test — a structured session attaches without it.
+      structuredNativeChat: false,
+      readSeededLaunchDraft: () => null,
+      sleep: async () => {}
+    }
+    act(() => {
+      renderer = create(createElement(Harness, { args }))
+    })
+
+    await act(async () => {
+      await hook!.attachImage('library')
+    })
+    await act(async () => {
+      expect(await hook!.sendNativeChat('look at this')).toBe(true)
+    })
+
+    const sendCalls = client.calls.filter((call) => call.method === 'terminal.send')
+    expect(sendCalls[1]?.params).toMatchObject({ text: expected, enter: false })
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
@@ -63,6 +63,7 @@ const SCOPE_B = 'h\0w\0tab-b'
 function baseArgs(overrides: Partial<HookArgs> & Pick<HookArgs, 'client'>): HookArgs {
   return {
     activeHandleRef: { current: 'term-1' },
+    agentRef: { current: 'claude' },
     deviceTokenRef: { current: null },
     getActiveWorktreeConnectionId: async () => null,
     connState: 'connected',

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.ts
@@ -65,6 +65,9 @@ type Args = {
   ) => Promise<MobileNativeChatSendOutcome>
   /** Structured sessions send attachments without the terminal paste path. */
   readonly structuredNativeChat: boolean
+  /** Agent on the tab the paste targets, read at send time (a ref, because the
+   *  active tab can change between render and submit). Picks the attachment form. */
+  readonly agentRef: CurrentRef<string | null>
   /** Launch-context text parked on the agent's TUI input line, or null. The
    *  paste's leading clear must cover every line of it, or the draft's earlier
    *  lines survive and ride along with the image. */
@@ -101,6 +104,7 @@ export function useMobileNativeChatImageAttachments({
   onSendError,
   baseSend,
   structuredNativeChat,
+  agentRef,
   readSeededLaunchDraft,
   onAttachSuccess,
   onError,
@@ -240,6 +244,7 @@ export function useMobileNativeChatImageAttachments({
             terminal: handle,
             deviceToken: deviceTokenRef.current,
             imagePaths: pendingImages.map((attachment) => attachment.path),
+            agent: agentRef.current,
             followedByText: text.trim().length > 0,
             deadline,
             ...(seededLaunchDraft
@@ -313,6 +318,7 @@ export function useMobileNativeChatImageAttachments({
     },
     [
       activeHandleRef,
+      agentRef,
       attachmentsByScope,
       baseSend,
       client,

--- a/mobile/src/session/use-mobile-session-attachments.ts
+++ b/mobile/src/session/use-mobile-session-attachments.ts
@@ -82,6 +82,7 @@ export function useMobileSessionAttachments(scope: MobileSessionAccessorySelecti
     beforeTerminalSend: flushPendingLiveInputBeforeAttachmentSend,
     nativeChatBaseSend: nativeChatController.handleNativeChatSendWithOutcome,
     structuredNativeChat: activeSessionTab?.type === 'agent-session',
+    nativeChatAgentRef: nativeChatController.nativeChatAgentRef,
     readSeededLaunchDraft: nativeChatController.readSeededLaunchDraft,
     showToast,
     onNativeChatSendError: nativeChatSendError.show,

--- a/mobile/src/session/use-mobile-session-image-attachments.ts
+++ b/mobile/src/session/use-mobile-session-image-attachments.ts
@@ -38,6 +38,8 @@ type Args = {
   ) => Promise<MobileNativeChatSendOutcome>
   /** Structured agent sessions do not have a terminal paste path. */
   readonly structuredNativeChat: boolean
+  /** Agent on the chat tab, read at send time — picks the attachment form. */
+  readonly nativeChatAgentRef: CurrentRef<string | null>
   /** Launch-context text parked on the agent's TUI input line, or null — sizes
    *  the image paste's leading clear so a multi-line draft cannot ride along. */
   readonly readSeededLaunchDraft: () => string | null
@@ -65,6 +67,7 @@ export function useMobileSessionImageAttachments({
   beforeTerminalSend,
   nativeChatBaseSend,
   structuredNativeChat,
+  nativeChatAgentRef,
   readSeededLaunchDraft,
   showToast,
   onNativeChatSendError,
@@ -96,6 +99,7 @@ export function useMobileSessionImageAttachments({
     scopeKey: nativeChatScopeKey,
     enabled: structuredNativeChat ? connState === 'connected' : nativeChatInputLeaseReady,
     structuredNativeChat,
+    agentRef: nativeChatAgentRef,
     showToast,
     onSendError: onNativeChatSendError,
     baseSend: nativeChatBaseSend,

--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -433,6 +433,32 @@ describe('NativeChatComposer', () => {
     expect(mocks.sendNativeChatMessageWithImageAttachments).toHaveBeenCalledWith(
       {},
       'pty-1',
+      'codex',
+      'hello',
+      ['/tmp/pasted.png'],
+      undefined
+    )
+  })
+
+  // The composer owns which agent the send path branches on; a dropped prop
+  // would silently give every agent the image-paste form again.
+  it('forwards the pane agent so the send path can pick the attachment form', () => {
+    mocks.imageAttachments = [{ id: 'image-1', path: '/tmp/pasted.png' }]
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="omp"
+      />
+    )
+
+    act(() => mocks.fieldProps?.onSend?.())
+
+    expect(mocks.sendNativeChatMessageWithImageAttachments).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      'omp',
       'hello',
       ['/tmp/pasted.png'],
       undefined

--- a/src/renderer/src/components/native-chat/native-chat-composer-target.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-target.ts
@@ -2,6 +2,8 @@ import { translate } from '@/i18n/i18n'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import type { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
 
+export { formatNativeChatFileReference } from '../../../../shared/native-chat-paste-bytes'
+
 export type NativeChatResolvedTarget = {
   ptyId: string
   settings: ReturnType<typeof getSettingsForAgentTabRuntimeOwner>
@@ -26,9 +28,4 @@ export function nativeChatComposerPlaceholder(hasPty: boolean, canSend: boolean)
 
 export function nativeChatComposerTargetIsRemote(ptyId: string | null): boolean {
   return ptyId !== null && isRemoteRuntimePtyId(ptyId)
-}
-
-export function formatNativeChatFileReference(filePath: string): string {
-  const escaped = filePath.replace(/"/g, '\\"')
-  return /\s/.test(filePath) ? `@"${escaped}"` : `@${filePath}`
 }

--- a/src/renderer/src/components/native-chat/native-chat-runtime-image-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-image-send.ts
@@ -1,9 +1,10 @@
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import type { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
-import { imagePasteWritesFollowedByText } from '../../../../shared/image-paste-following-text'
+import type { AgentType } from '../../../../shared/agent-status-types'
 import { NATIVE_CHAT_SUBMIT_DELAY_MS } from '../../../../shared/native-chat-answer-stepping'
+import { getNativeChatAttachmentForm } from '../../../../shared/native-chat-agent-profiles'
 import {
-  buildNativeChatImagePasteBytes,
+  buildNativeChatAttachmentWrites,
   buildNativeChatPasteBytes,
   NATIVE_CHAT_SUBMIT
 } from './native-chat-send'
@@ -21,9 +22,13 @@ export const NATIVE_CHAT_IMAGE_ATTACHMENT_SETTLE_MS = 300
 
 type RuntimeSettings = ReturnType<typeof getSettingsForAgentTabRuntimeOwner>
 
+/** `agent` picks the attachment form: only agents with a verified image-paste
+ *  gesture get a bracketed raw path; the rest get `@path` (see
+ *  getNativeChatAttachmentForm). */
 export function sendNativeChatMessageWithImageAttachments(
   settings: RuntimeSettings,
   ptyId: string,
+  agent: AgentType | null | undefined,
   text: string,
   imagePaths: readonly string[],
   options?: NativeChatSendOptions
@@ -47,8 +52,9 @@ export function sendNativeChatMessageWithImageAttachments(
         if (isCancelled()) {
           return
         }
-        for (const payload of imagePasteWritesFollowedByText(
-          imagePaths.map(buildNativeChatImagePasteBytes),
+        for (const payload of buildNativeChatAttachmentWrites(
+          imagePaths,
+          getNativeChatAttachmentForm(agent),
           trimmedText.length > 0
         )) {
           sendRuntimePtyInput(settings, ptyId, payload)

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send-launch-draft.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send-launch-draft.test.ts
@@ -161,7 +161,7 @@ describe('sendNativeChatMessage with a parked multi-line draft', () => {
 describe('image sends with a parked multi-line draft', () => {
   it('clears every draft line before pasting, so no line rides along with the image', () => {
     const clearInput = buildAgentTuiClearInputForText(DRAFT)
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'caption', ['/tmp/a.png'], {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'caption', ['/tmp/a.png'], {
       clearInput
     })
     expect(writes()[0]).toBe(clearInput)
@@ -169,7 +169,7 @@ describe('image sends with a parked multi-line draft', () => {
 
   it('clears exactly once — a second Ctrl+U would wipe the just-pasted image', () => {
     const clearInput = buildAgentTuiClearInputForText(DRAFT)
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'caption', ['/tmp/a.png'], {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'caption', ['/tmp/a.png'], {
       clearInput
     })
     vi.advanceTimersByTime(10_000)
@@ -178,7 +178,7 @@ describe('image sends with a parked multi-line draft', () => {
 
   it('submits the image send before a queued message starts', async () => {
     const clearInput = buildAgentTuiClearInputForText(DRAFT)
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'caption', ['/tmp/a.png'], {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'caption', ['/tmp/a.png'], {
       clearInput,
       confirmCleared: () => true
     })

--- a/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-runtime-send.test.ts
@@ -327,9 +327,13 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('clears the line, then bracket-pastes image paths before prompt text', () => {
-    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'what do you see?', [
-      '/tmp/orca-paste-image.png'
-    ])
+    const handle = sendNativeChatMessageWithImageAttachments(
+      SETTINGS,
+      PTY,
+      'claude',
+      'what do you see?',
+      ['/tmp/orca-paste-image.png']
+    )
 
     expect(handle.settleAfterMs).toBe(
       NATIVE_CHAT_IMAGE_ATTACHMENT_SETTLE_MS + NATIVE_CHAT_SUBMIT_DELAY_MS
@@ -350,7 +354,7 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('does not append a trailing separator on an attachment-only send', () => {
-    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, '', [
+    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', '', [
       '/tmp/orca-paste-image.png'
     ])
 
@@ -370,7 +374,9 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('treats whitespace-only prompt input as attachment-only', () => {
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, '   ', ['/tmp/orca-paste-image.png'])
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', '   ', [
+      '/tmp/orca-paste-image.png'
+    ])
 
     expectWriteOrder(sendRuntimePtyInput.mock.calls, [
       NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
@@ -378,8 +384,24 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
     ])
   })
 
+  it('sends an @path reference, not a bracketed frame, to an agent with no image paste', () => {
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'omp', 'hello', [
+      '/tmp/a.png',
+      '/tmp/b.png'
+    ])
+
+    expectWriteOrder(sendRuntimePtyInput.mock.calls, [
+      NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
+      '@/tmp/a.png ',
+      '@/tmp/b.png '
+    ])
+  })
+
   it('keeps multiple image frames bare and separates only the final frame from prompt text', () => {
-    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'hello', ['/tmp/a.png', '/tmp/b.png'])
+    sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'hello', [
+      '/tmp/a.png',
+      '/tmp/b.png'
+    ])
 
     expectWriteOrder(sendRuntimePtyInput.mock.calls, [
       NATIVE_CHAT_CLEAR_UNSUBMITTED_INPUT,
@@ -389,7 +411,7 @@ describe('sendNativeChatMessageWithImageAttachments', () => {
   })
 
   it('cancels deferred prompt and Enter writes after the attachment path', () => {
-    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'describe', [
+    const handle = sendNativeChatMessageWithImageAttachments(SETTINGS, PTY, 'claude', 'describe', [
       '/tmp/orca-paste-image.png'
     ])
     handle.cancel()

--- a/src/renderer/src/components/native-chat/native-chat-send.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import { NATIVE_CHAT_SUPPORTED_AGENT_LIST } from '../../../../shared/native-chat-agent-support'
+import { getNativeChatAttachmentForm } from '../../../../shared/native-chat-agent-profiles'
+import { getAgentImageHandling } from './native-chat-image-paste'
 import {
-  buildNativeChatImagePasteBytes,
+  buildNativeChatAttachmentBytes,
+  buildNativeChatAttachmentWrites,
   buildNativeChatPasteBytes,
   buildNativeChatSendBytes,
   isMultilineDraft,
@@ -46,17 +50,94 @@ describe('buildNativeChatPasteBytes', () => {
   })
 })
 
-describe('buildNativeChatImagePasteBytes', () => {
-  it('always bracket-pastes the image path so agent TUIs attach it as an image', () => {
-    expect(buildNativeChatImagePasteBytes('/tmp/orca-paste-image.png')).toBe(
+describe('buildNativeChatAttachmentBytes', () => {
+  it('bracket-pastes the image path for agents that attach a pasted path', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/orca-paste-image.png', 'image-paste')).toBe(
       `${BEGIN}/tmp/orca-paste-image.png${END}`
     )
   })
 
   it('sanitizes embedded escape bytes before framing', () => {
-    expect(buildNativeChatImagePasteBytes('/tmp/before\x1b[201~after.png')).toBe(
+    expect(buildNativeChatAttachmentBytes('/tmp/before\x1b[201~after.png', 'image-paste')).toBe(
       `${BEGIN}/tmp/before␛[201~after.png${END}`
     )
+  })
+
+  it('sends an unframed @path for agents with no image-paste gesture', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/orca-paste-image.png', 'file-reference')).toBe(
+      '@/tmp/orca-paste-image.png'
+    )
+  })
+
+  it('quotes a spaced path and sanitizes escape bytes in the reference form', () => {
+    expect(buildNativeChatAttachmentBytes('C:\\My Shots\\a.png', 'file-reference')).toBe(
+      '@"C:\\My Shots\\a.png"'
+    )
+    expect(buildNativeChatAttachmentBytes('/tmp/a\x1b[201~b.png', 'file-reference')).toBe(
+      '@/tmp/a␛[201~b.png'
+    )
+  })
+
+  // An unframed write is keystrokes: a CR in a filename would submit the turn.
+  it('frames a reference whose path carries a line break instead of writing a bare CR', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/a\nb.png', 'file-reference')).toBe(
+      `${BEGIN}@"/tmp/a\rb.png"${END}`
+    )
+    expect(buildNativeChatAttachmentBytes('/tmp/a\rb.png', 'file-reference')).toBe(
+      `${BEGIN}@"/tmp/a\rb.png"${END}`
+    )
+  })
+
+  // The A1 regression: two Native-Chat agents must not share one attachment form.
+  it('emits a different form for an unverified agent than for Claude', () => {
+    const path = '/tmp/shot.png'
+    expect(buildNativeChatAttachmentBytes(path, getNativeChatAttachmentForm('claude'))).not.toBe(
+      buildNativeChatAttachmentBytes(path, getNativeChatAttachmentForm('omp'))
+    )
+  })
+
+  // Expected bytes are literal, not derived from the function under test, so a
+  // table flip that made every agent agree would fail here.
+  it.each([
+    ['claude', `${BEGIN}/tmp/shot.png${END}`],
+    ['openclaude', `${BEGIN}/tmp/shot.png${END}`],
+    ['codex', `${BEGIN}/tmp/shot.png${END}`],
+    ['grok', `${BEGIN}/tmp/shot.png${END}`],
+    ['omp', '@/tmp/shot.png']
+  ] as const)('%s attaches /tmp/shot.png as %s', (agent, expected) => {
+    expect(
+      buildNativeChatAttachmentBytes('/tmp/shot.png', getNativeChatAttachmentForm(agent))
+    ).toBe(expected)
+  })
+
+  it('covers every native-chat agent in the table above', () => {
+    expect([...NATIVE_CHAT_SUPPORTED_AGENT_LIST].sort()).toEqual(
+      ['claude', 'codex', 'grok', 'omp', 'openclaude'].sort()
+    )
+  })
+})
+
+describe('buildNativeChatAttachmentWrites', () => {
+  it('leaves back-to-back image frames bare and separates only the last from text', () => {
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'image-paste', true)
+    ).toEqual([`${BEGIN}/tmp/a.png${END}`, `${BEGIN}/tmp/b.png${END} `])
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'image-paste', false)
+    ).toEqual([`${BEGIN}/tmp/a.png${END}`, `${BEGIN}/tmp/b.png${END}`])
+  })
+
+  it('separates every @path reference, which is not self-delimiting', () => {
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'file-reference', true)
+    ).toEqual(['@/tmp/a.png ', '@/tmp/b.png '])
+    expect(
+      buildNativeChatAttachmentWrites(['/tmp/a.png', '/tmp/b.png'], 'file-reference', false)
+    ).toEqual(['@/tmp/a.png ', '@/tmp/b.png'])
+  })
+
+  it('writes nothing when there are no attachments', () => {
+    expect(buildNativeChatAttachmentWrites([], 'file-reference', true)).toEqual([])
   })
 })
 
@@ -104,5 +185,17 @@ describe('isMultilineDraft', () => {
   })
   it('is true when a newline is present', () => {
     expect(isMultilineDraft('a\nb')).toBe(true)
+  })
+})
+
+// Two per-agent tables answer "does this agent attach a pasted path?": the send
+// side's attachmentForm and the clipboard side's IMAGE_ATTACHMENT_AGENTS. They
+// must agree, or a drop and a paste of the same image reach the agent differently.
+describe('attachment form agrees with clipboard image handling', () => {
+  it.each(NATIVE_CHAT_SUPPORTED_AGENT_LIST)('%s', (agent) => {
+    const acceptsPastedPath = getAgentImageHandling(agent) === 'attachment'
+    expect(getNativeChatAttachmentForm(agent)).toBe(
+      acceptsPastedPath ? 'image-paste' : 'file-reference'
+    )
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.ts
@@ -7,7 +7,6 @@ export {
   buildNativeChatAttachmentBytes,
   buildNativeChatAttachmentWrites,
   buildNativeChatPasteBytes,
-  formatNativeChatFileReference,
   isMultilineDraft
 } from '../../../../shared/native-chat-paste-bytes'
 

--- a/src/renderer/src/components/native-chat/native-chat-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.ts
@@ -1,87 +1,23 @@
 // Pure: turn raw composer text into the exact PTY bytes to write. Kept separate
 // from the React composer so the byte rules are unit-testable without a DOM.
 
-import type { NativeChatAttachmentForm } from '../../../../shared/native-chat-agent-profiles'
-import {
-  imagePasteWritesFollowedByText,
-  separateImagePasteFromFollowingText
-} from '../../../../shared/image-paste-following-text'
-import {
-  sanitizeBracketedPasteText,
-  wrapTerminalBracketedPasteText
-} from '../terminal-pane/terminal-bracketed-paste'
-import { formatNativeChatFileReference } from './native-chat-composer-target'
+import { buildNativeChatPasteBytes } from '../../../../shared/native-chat-paste-bytes'
+
+export {
+  buildNativeChatAttachmentBytes,
+  buildNativeChatAttachmentWrites,
+  buildNativeChatPasteBytes,
+  formatNativeChatFileReference,
+  isMultilineDraft
+} from '../../../../shared/native-chat-paste-bytes'
 
 // Why: carriage return (not \n) is what xterm/agent composers treat as the
 // submit/Enter key over a PTY.
 const SUBMIT = '\r'
 
-/** True when the draft spans more than one line (so it needs bracketed-paste
- *  wrapping). A trailing newline alone still counts as multi-line. */
-export function isMultilineDraft(text: string): boolean {
-  return /[\r\n]/.test(text)
-}
-
 /** The carriage-return submit byte, exported so send paths can write Enter as a
  *  SEPARATE pty write after the framed body (see buildNativeChatPasteBytes). */
 export const NATIVE_CHAT_SUBMIT = SUBMIT
-
-/**
- * Compute the bytes for `text` WITHOUT the trailing submit:
- *  - single-line → `text`
- *  - multi-line  → `\x1b[200~…\x1b[201~` (bracketed-paste wrapped, no submit)
- *
- * Why split the submit out: agent TUIs treat a framed paste that carries a
- * trailing `\r` in the SAME pty write as part of the paste body rather than an
- * Enter, so the text lands in the input box but never sends. Callers write this
- * body first, then write `NATIVE_CHAT_SUBMIT` as a separate, slightly-delayed
- * write (mirrors orca-runtime's writeTerminalAction Enter handling).
- */
-export function buildNativeChatPasteBytes(text: string): string {
-  if (isMultilineDraft(text)) {
-    return wrapTerminalBracketedPasteText(text)
-  }
-  // Why: sanitize even unframed text so pasted scrollback cannot carry a raw
-  // terminal escape into the agent composer.
-  return sanitizeBracketedPasteText(text)
-}
-
-/**
- * One attachment's bytes, in the form its agent understands:
- *  - `image-paste` → bracketed paste of the raw path. Claude/Codex/Grok TUIs
- *    detect that gesture and attach the file as an image; a plain typed path (or
- *    @file mention) would be treated as text/file-read instead.
- *  - `file-reference` → the portable `@path` mention. Agents with no verified
- *    image-paste gesture would otherwise receive a naked path as prose.
- */
-export function buildNativeChatAttachmentBytes(
-  filePath: string,
-  form: NativeChatAttachmentForm
-): string {
-  if (form === 'file-reference') {
-    // Why: an unframed write is keystrokes, so a filename holding CR/LF would
-    // submit the turn early. buildNativeChatPasteBytes already frames those.
-    return buildNativeChatPasteBytes(formatNativeChatFileReference(filePath))
-  }
-  return wrapTerminalBracketedPasteText(filePath)
-}
-
-/** The per-attachment PTY writes for a send. Bracketed image frames are
- *  self-delimiting, so only the last needs a space before prompt text; `@path`
- *  references are plain text and need one between every pair as well. */
-export function buildNativeChatAttachmentWrites(
-  filePaths: readonly string[],
-  form: NativeChatAttachmentForm,
-  followedByText: boolean
-): string[] {
-  const payloads = filePaths.map((filePath) => buildNativeChatAttachmentBytes(filePath, form))
-  if (form === 'image-paste') {
-    return imagePasteWritesFollowedByText(payloads, followedByText)
-  }
-  return payloads.map((payload, index) =>
-    separateImagePasteFromFollowingText(payload, index < payloads.length - 1 || followedByText)
-  )
-}
 
 /**
  * Compute the bytes to write for `text` + Enter in ONE write:

--- a/src/renderer/src/components/native-chat/native-chat-send.ts
+++ b/src/renderer/src/components/native-chat/native-chat-send.ts
@@ -1,10 +1,16 @@
 // Pure: turn raw composer text into the exact PTY bytes to write. Kept separate
 // from the React composer so the byte rules are unit-testable without a DOM.
 
+import type { NativeChatAttachmentForm } from '../../../../shared/native-chat-agent-profiles'
+import {
+  imagePasteWritesFollowedByText,
+  separateImagePasteFromFollowingText
+} from '../../../../shared/image-paste-following-text'
 import {
   sanitizeBracketedPasteText,
   wrapTerminalBracketedPasteText
 } from '../terminal-pane/terminal-bracketed-paste'
+import { formatNativeChatFileReference } from './native-chat-composer-target'
 
 // Why: carriage return (not \n) is what xterm/agent composers treat as the
 // submit/Enter key over a PTY.
@@ -40,10 +46,41 @@ export function buildNativeChatPasteBytes(text: string): string {
   return sanitizeBracketedPasteText(text)
 }
 
-/** Image attachments must look like a real terminal image paste to Claude/Codex
- *  TUIs. A plain typed path (or @file mention) is treated as text/file-read. */
-export function buildNativeChatImagePasteBytes(filePath: string): string {
+/**
+ * One attachment's bytes, in the form its agent understands:
+ *  - `image-paste` → bracketed paste of the raw path. Claude/Codex/Grok TUIs
+ *    detect that gesture and attach the file as an image; a plain typed path (or
+ *    @file mention) would be treated as text/file-read instead.
+ *  - `file-reference` → the portable `@path` mention. Agents with no verified
+ *    image-paste gesture would otherwise receive a naked path as prose.
+ */
+export function buildNativeChatAttachmentBytes(
+  filePath: string,
+  form: NativeChatAttachmentForm
+): string {
+  if (form === 'file-reference') {
+    // Why: an unframed write is keystrokes, so a filename holding CR/LF would
+    // submit the turn early. buildNativeChatPasteBytes already frames those.
+    return buildNativeChatPasteBytes(formatNativeChatFileReference(filePath))
+  }
   return wrapTerminalBracketedPasteText(filePath)
+}
+
+/** The per-attachment PTY writes for a send. Bracketed image frames are
+ *  self-delimiting, so only the last needs a space before prompt text; `@path`
+ *  references are plain text and need one between every pair as well. */
+export function buildNativeChatAttachmentWrites(
+  filePaths: readonly string[],
+  form: NativeChatAttachmentForm,
+  followedByText: boolean
+): string[] {
+  const payloads = filePaths.map((filePath) => buildNativeChatAttachmentBytes(filePath, form))
+  if (form === 'image-paste') {
+    return imagePasteWritesFollowedByText(payloads, followedByText)
+  }
+  return payloads.map((payload, index) =>
+    separateImagePasteFromFollowingText(payload, index < payloads.length - 1 || followedByText)
+  )
 }
 
 /**

--- a/src/renderer/src/components/native-chat/use-native-chat-pty-composer-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pty-composer-send.ts
@@ -74,6 +74,7 @@ export function useNativeChatPtyComposerSend(args: {
       pendingHandle = sendNativeChatMessageWithImageAttachments(
         target.settings,
         target.ptyId,
+        args.agent,
         text,
         imagePaths,
         sendOptions

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -1,5 +1,17 @@
 import type { Terminal } from '@xterm/xterm'
+import {
+  sanitizeBracketedPasteText,
+  wrapTerminalBracketedPasteText
+} from '../../../../shared/bracketed-paste-text'
 import type { WindowsInputRecordNewline } from './terminal-paste-model'
+
+export {
+  BRACKETED_PASTE_END,
+  BRACKETED_PASTE_START,
+  normalizeTerminalPasteLineEndings,
+  sanitizeBracketedPasteText,
+  wrapTerminalBracketedPasteText
+} from '../../../../shared/bracketed-paste-text'
 
 type BracketedPasteTerminal = {
   modes: {
@@ -21,8 +33,6 @@ type PasteTerminalTextOptions = {
 const interruptedBracketedPasteTerminals = new WeakSet<object>()
 const bracketedPasteModeOutputTail = new WeakMap<object, string>()
 const ESCAPE = '\u001b'
-export const BRACKETED_PASTE_START = `${ESCAPE}[200~`
-export const BRACKETED_PASTE_END = `${ESCAPE}[201~`
 const BRACKETED_PASTE_MODE_SEQUENCE_RE = /^\[\?(?:\d+;)*2004(?:;\d+)*[hl]/
 const BRACKETED_PASTE_MODE_TAIL_MAX = 128
 const BRACKETED_PASTE_MODE_SEQUENCE_SCAN_MAX = BRACKETED_PASTE_MODE_TAIL_MAX
@@ -45,38 +55,8 @@ function hasBracketedPasteModeSequence(data: string): boolean {
   return false
 }
 
-// Why: an embedded ESC (e.g. a pasted `\x1b[201~` from scrollback) would close
-// the bracketed-paste frame early and run the tail as keystrokes. Replacing ESC
-// with its printable substitute (\u241b, U+241B) neutralizes every framing escape.
-export function sanitizeBracketedPasteText(text: string): string {
-  let escapeIndex = text.indexOf(ESCAPE)
-  if (escapeIndex === -1) {
-    return text
-  }
-
-  let sanitized = ''
-  let start = 0
-  while (escapeIndex !== -1) {
-    sanitized += `${text.slice(start, escapeIndex)}\u241b`
-    start = escapeIndex + ESCAPE.length
-    escapeIndex = text.indexOf(ESCAPE, start)
-  }
-  return sanitized + text.slice(start)
-}
-
 export function sanitizeTerminalPasteText(text: string): string {
   return sanitizeBracketedPasteText(text)
-}
-
-export function normalizeTerminalPasteLineEndings(text: string): string {
-  // Why: xterm's native paste path converts every clipboard newline to CR.
-  // Direct frames must match it or ConPTY TUIs can treat raw LF as submit.
-  return text.replace(/\r?\n/g, '\r')
-}
-
-export function wrapTerminalBracketedPasteText(text: string): string {
-  const normalizedText = normalizeTerminalPasteLineEndings(text)
-  return `${BRACKETED_PASTE_START}${sanitizeBracketedPasteText(normalizedText)}${BRACKETED_PASTE_END}`
 }
 
 export function encodeWindowsInputRecordPasteText(

--- a/src/shared/bracketed-paste-text.ts
+++ b/src/shared/bracketed-paste-text.ts
@@ -2,7 +2,7 @@
 // the native-chat attachment builders must frame and sanitize identically — a
 // frame that differs by platform is a submit-early bug waiting to happen.
 
-const ESCAPE = ''
+const ESCAPE = '\u001b'
 export const BRACKETED_PASTE_START = `${ESCAPE}[200~`
 export const BRACKETED_PASTE_END = `${ESCAPE}[201~`
 
@@ -18,7 +18,7 @@ export function sanitizeBracketedPasteText(text: string): string {
   let sanitized = ''
   let start = 0
   while (escapeIndex !== -1) {
-    sanitized += `${text.slice(start, escapeIndex)}␛`
+    sanitized += `${text.slice(start, escapeIndex)}\u241b`
     start = escapeIndex + ESCAPE.length
     escapeIndex = text.indexOf(ESCAPE, start)
   }

--- a/src/shared/bracketed-paste-text.ts
+++ b/src/shared/bracketed-paste-text.ts
@@ -1,0 +1,37 @@
+// Pure bracketed-paste framing. Shared because the desktop terminal, mobile, and
+// the native-chat attachment builders must frame and sanitize identically — a
+// frame that differs by platform is a submit-early bug waiting to happen.
+
+const ESCAPE = ''
+export const BRACKETED_PASTE_START = `${ESCAPE}[200~`
+export const BRACKETED_PASTE_END = `${ESCAPE}[201~`
+
+// Why: an embedded ESC (e.g. a pasted `\x1b[201~` from scrollback) would close
+// the bracketed-paste frame early and run the tail as keystrokes. Replacing ESC
+// with its printable substitute (␛, U+241B) neutralizes every framing escape.
+export function sanitizeBracketedPasteText(text: string): string {
+  let escapeIndex = text.indexOf(ESCAPE)
+  if (escapeIndex === -1) {
+    return text
+  }
+
+  let sanitized = ''
+  let start = 0
+  while (escapeIndex !== -1) {
+    sanitized += `${text.slice(start, escapeIndex)}␛`
+    start = escapeIndex + ESCAPE.length
+    escapeIndex = text.indexOf(ESCAPE, start)
+  }
+  return sanitized + text.slice(start)
+}
+
+export function normalizeTerminalPasteLineEndings(text: string): string {
+  // Why: xterm's native paste path converts every clipboard newline to CR.
+  // Direct frames must match it or ConPTY TUIs can treat raw LF as submit.
+  return text.replace(/\r?\n/g, '\r')
+}
+
+export function wrapTerminalBracketedPasteText(text: string): string {
+  const normalizedText = normalizeTerminalPasteLineEndings(text)
+  return `${BRACKETED_PASTE_START}${sanitizeBracketedPasteText(normalizedText)}${BRACKETED_PASTE_END}`
+}

--- a/src/shared/native-chat-agent-profiles.test.ts
+++ b/src/shared/native-chat-agent-profiles.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { NATIVE_CHAT_SUPPORTED_AGENT_LIST } from './native-chat-agent-support'
 import {
   getHostClaimedNativeChatCommands,
   getNativeChatAgentProfile,
+  getNativeChatAttachmentForm,
   getVerifiedNativeChatCommands
 } from './native-chat-agent-profiles'
 
@@ -54,5 +56,35 @@ describe('host-claimed native chat commands', () => {
   it('claims the whole catalog for agents with no pass-through policy', () => {
     expect(names('custom-agent')).toEqual(['clear', 'help'])
     expect(names('grok')).toEqual([])
+  })
+})
+
+describe('native chat attachment form', () => {
+  it.each([
+    ['claude', 'image-paste'],
+    ['openclaude', 'image-paste'],
+    ['codex', 'image-paste'],
+    ['grok', 'image-paste'],
+    // OMP wraps Pi's TUI, which has no verified image-path paste gesture.
+    ['omp', 'file-reference'],
+    ['custom-agent', 'file-reference']
+  ] as const)('%s attaches as %s', (agent, form) => {
+    expect(getNativeChatAttachmentForm(agent)).toBe(form)
+  })
+
+  it('never leaves a native-chat agent without a form', () => {
+    for (const agent of NATIVE_CHAT_SUPPORTED_AGENT_LIST) {
+      expect(getNativeChatAttachmentForm(agent)).toMatch(/^(image-paste|file-reference)$/)
+    }
+  })
+
+  it('does not give every native-chat agent the same form', () => {
+    const forms = new Set(NATIVE_CHAT_SUPPORTED_AGENT_LIST.map(getNativeChatAttachmentForm))
+    expect(forms.size).toBeGreaterThan(1)
+  })
+
+  it('falls back to the reference form for an unknown agent', () => {
+    expect(getNativeChatAttachmentForm(null)).toBe('file-reference')
+    expect(getNativeChatAttachmentForm(undefined)).toBe('file-reference')
   })
 })

--- a/src/shared/native-chat-agent-profiles.ts
+++ b/src/shared/native-chat-agent-profiles.ts
@@ -1,6 +1,12 @@
 import type { AgentType } from './agent-status-types'
 import { getAgentSlashCommands, type SlashCommandSuggestion } from './native-chat-slash-commands'
 
+/** How an agent takes a composer attachment. `image-paste` bracket-pastes the
+ *  raw path, which only agents with a verified image-paste gesture turn into an
+ *  attachment chip; `file-reference` sends the portable `@path` mention, which
+ *  every other agent reads as a file to open rather than as prose. */
+export type NativeChatAttachmentForm = 'image-paste' | 'file-reference'
+
 export type NativeChatAgentProfile = {
   skillPrefix: '$' | '/'
   /** OpenClaude reads Claude-owned roots, so this can differ from the agent. */
@@ -11,6 +17,7 @@ export type NativeChatAgentProfile = {
   /** Catalog commands the model acts on when they arrive as prose, even though
    *  the runtime has no slash parser of its own. */
   textDrivenCommands?: readonly string[]
+  attachmentForm: NativeChatAttachmentForm
 }
 
 const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfile>> = {
@@ -19,21 +26,25 @@ const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfi
     skillSourceOwner: 'codex',
     // The app-server has no slash parser, but the model owns goal tools and
     // calls create_goal itself when `/goal <objective>` reaches it as prose.
-    textDrivenCommands: ['goal']
+    textDrivenCommands: ['goal'],
+    attachmentForm: 'image-paste'
   },
   claude: {
     skillPrefix: '/',
     skillSourceOwner: 'claude',
-    expandsSlashCommandsFromText: true
+    expandsSlashCommandsFromText: true,
+    attachmentForm: 'image-paste'
   },
   openclaude: {
     skillPrefix: '/',
     skillSourceOwner: 'claude',
-    expandsSlashCommandsFromText: true
+    expandsSlashCommandsFromText: true,
+    attachmentForm: 'image-paste'
   },
   grok: {
     skillPrefix: '/',
-    skillSourceOwner: 'grok'
+    skillSourceOwner: 'grok',
+    attachmentForm: 'image-paste'
   }
 }
 
@@ -41,6 +52,15 @@ export function getNativeChatAgentProfile(
   agent: AgentType | null | undefined
 ): NativeChatAgentProfile | null {
   return agent ? (NATIVE_CHAT_AGENT_PROFILES[agent] ?? null) : null
+}
+
+/** Attachment form for an agent. Agents without a verified profile fall back to
+ *  `@path`: an unverified TUI has no image-paste gesture, so a bracketed raw
+ *  path would land in its composer as text the model reads as prose. */
+export function getNativeChatAttachmentForm(
+  agent: AgentType | null | undefined
+): NativeChatAttachmentForm {
+  return getNativeChatAgentProfile(agent)?.attachmentForm ?? 'file-reference'
 }
 
 /** The catalog that send classification, collision detection, and transcript

--- a/src/shared/native-chat-paste-bytes.test.ts
+++ b/src/shared/native-chat-paste-bytes.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildNativeChatAttachmentBytes,
+  buildNativeChatAttachmentWrites,
+  buildNativeChatPasteBytes,
+  formatNativeChatFileReference,
+  isMultilineDraft,
+  needsBracketedFraming
+} from './native-chat-paste-bytes'
+
+const BEGIN = '\x1b[200~'
+const END = '\x1b[201~'
+
+describe('formatNativeChatFileReference', () => {
+  it('leaves a simple path unquoted', () => {
+    expect(formatNativeChatFileReference('/tmp/a.png')).toBe('@/tmp/a.png')
+  })
+
+  it('quotes a path containing whitespace', () => {
+    expect(formatNativeChatFileReference('/tmp/a b.png')).toBe('@"/tmp/a b.png"')
+  })
+
+  it('quotes a path containing a quote even without whitespace', () => {
+    // Why: escaping a quote only makes sense inside a quoted token; emitting
+    // `@/tmp/say\"hi.png` would hand the parser a stray escape.
+    expect(formatNativeChatFileReference('/tmp/say"hi.png')).toBe('@"/tmp/say\\"hi.png"')
+  })
+
+  it('quotes and escapes a path containing both', () => {
+    expect(formatNativeChatFileReference('/tmp/a "b".png')).toBe('@"/tmp/a \\"b\\".png"')
+  })
+})
+
+describe('needsBracketedFraming', () => {
+  it('frames CR and LF so a pasted value cannot submit the turn', () => {
+    expect(needsBracketedFraming('a\rb')).toBe(true)
+    expect(needsBracketedFraming('a\nb')).toBe(true)
+  })
+
+  it('frames other control bytes that would act as keys', () => {
+    expect(needsBracketedFraming('a\tb')).toBe(true)
+    expect(needsBracketedFraming('a\u0000b')).toBe(true)
+    expect(needsBracketedFraming('a\u007fb')).toBe(true)
+  })
+
+  it('excludes ESC, which sanitization neutralises instead of framing', () => {
+    expect(needsBracketedFraming('a\u001bb')).toBe(false)
+  })
+
+  it('does not frame ordinary text, including ordinary spaces', () => {
+    expect(needsBracketedFraming('/tmp/a b.png')).toBe(false)
+    expect(needsBracketedFraming('plain')).toBe(false)
+  })
+
+  it('is a superset of the multi-line trigger', () => {
+    expect(isMultilineDraft('a\nb')).toBe(true)
+    expect(needsBracketedFraming('a\nb')).toBe(true)
+    // A tab is not multi-line, but still must not go out as keystrokes.
+    expect(isMultilineDraft('a\tb')).toBe(false)
+    expect(needsBracketedFraming('a\tb')).toBe(true)
+  })
+})
+
+describe('buildNativeChatAttachmentBytes', () => {
+  it('bracket-pastes the raw path for agents with an image-paste gesture', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/a.png', 'image-paste')).toBe(
+      `${BEGIN}/tmp/a.png${END}`
+    )
+  })
+
+  it('leaves an ordinary file reference unframed', () => {
+    expect(buildNativeChatAttachmentBytes('/tmp/a.png', 'file-reference')).toBe('@/tmp/a.png')
+  })
+
+  it('frames a file reference whose name holds a control byte', () => {
+    // Why: a TAB is whitespace, so the reference is quoted as well as framed.
+    expect(buildNativeChatAttachmentBytes('/tmp/a\tb.png', 'file-reference')).toBe(
+      `${BEGIN}@"/tmp/a\tb.png"${END}`
+    )
+  })
+
+  it('frames a file reference whose name holds CR/LF so it cannot submit early', () => {
+    const bytes = buildNativeChatAttachmentBytes('/tmp/a\rb.png', 'file-reference')
+    expect(bytes.startsWith(BEGIN)).toBe(true)
+    expect(bytes.endsWith(END)).toBe(true)
+    // The submit byte must not survive outside the frame.
+    expect(bytes.slice(BEGIN.length, bytes.length - END.length)).not.toBe('\r')
+  })
+
+  it('keeps sanitizing an unframed reference so a stray escape cannot reach the composer', () => {
+    // Why: ESC alone must stay unframed but neutralised, exactly as the escape
+    // case asserted in native-chat-send.test.ts.
+    const bytes = buildNativeChatAttachmentBytes('/tmp/a\u001bb.png', 'file-reference')
+    expect(bytes).toBe('@/tmp/a\u241bb.png')
+    expect(bytes).not.toContain('\u001b')
+  })
+})
+
+describe('buildNativeChatAttachmentWrites', () => {
+  it('separates every image paste pair and the trailing text', () => {
+    expect(buildNativeChatAttachmentWrites(['/a.png', '/b.png'], 'image-paste', true)).toEqual([
+      `${BEGIN}/a.png${END}`,
+      `${BEGIN}/b.png${END} `
+    ])
+  })
+
+  it('separates references from each other and from trailing text', () => {
+    expect(buildNativeChatAttachmentWrites(['/a.png', '/b.png'], 'file-reference', true)).toEqual([
+      '@/a.png ',
+      '@/b.png '
+    ])
+  })
+
+  it('does not add a trailing space when nothing follows', () => {
+    expect(buildNativeChatAttachmentWrites(['/a.png'], 'file-reference', false)).toEqual([
+      '@/a.png'
+    ])
+  })
+})
+
+describe('buildNativeChatPasteBytes', () => {
+  it('is unchanged for plain and multi-line bodies', () => {
+    expect(buildNativeChatPasteBytes('hello')).toBe('hello')
+    expect(buildNativeChatPasteBytes('a\nb')).toBe(`${BEGIN}a\rb${END}`)
+  })
+})

--- a/src/shared/native-chat-paste-bytes.ts
+++ b/src/shared/native-chat-paste-bytes.ts
@@ -35,9 +35,28 @@ export function buildNativeChatPasteBytes(text: string): string {
   return sanitizeBracketedPasteText(text)
 }
 
+/** True when unframed bytes would be interpreted as keys rather than pasted
+ *  literally: CR/LF submits the turn, and the other control bytes (TAB, C0, DEL)
+ *  act as keys. ESC is deliberately excluded — `sanitizeBracketedPasteText`
+ *  already neutralises it, so framing is not what defends that byte. */
+export function needsBracketedFraming(text: string): boolean {
+  for (const character of text) {
+    const code = character.charCodeAt(0)
+    if (code === 27) {
+      continue
+    }
+    if (code < 32 || code === 127) {
+      return true
+    }
+  }
+  return false
+}
+
 export function formatNativeChatFileReference(filePath: string): string {
   const escaped = filePath.replace(/"/g, '\\"')
-  return /\s/.test(filePath) ? `@"${escaped}"` : `@${filePath}`
+  // Why: a quote forces quoting too. Escaping only makes sense inside a quoted
+  // token, so an unquoted `@a\"b` would hand the parser a stray escape.
+  return /[\s"]/.test(filePath) ? `@"${escaped}"` : `@${filePath}`
 }
 
 /**
@@ -53,9 +72,13 @@ export function buildNativeChatAttachmentBytes(
   form: NativeChatAttachmentForm
 ): string {
   if (form === 'file-reference') {
-    // Why: an unframed write is keystrokes, so a filename holding CR/LF would
-    // submit the turn early. buildNativeChatPasteBytes already frames those.
-    return buildNativeChatPasteBytes(formatNativeChatFileReference(filePath))
+    const reference = formatNativeChatFileReference(filePath)
+    // Why: an unframed write is keystrokes, so CR/LF would submit the turn early
+    // and a TAB or other control byte in a file name would act as a key. Frame
+    // anything that is not safely literal; sanitize the rest.
+    return needsBracketedFraming(reference)
+      ? wrapTerminalBracketedPasteText(reference)
+      : sanitizeBracketedPasteText(reference)
   }
   return wrapTerminalBracketedPasteText(filePath)
 }

--- a/src/shared/native-chat-paste-bytes.ts
+++ b/src/shared/native-chat-paste-bytes.ts
@@ -1,0 +1,78 @@
+// Pure: the exact PTY bytes a native-chat send writes for its body and for each
+// attachment. Shared so desktop and mobile cannot drift on which agent gets a
+// bracketed image paste and which gets an `@path` reference.
+
+import { sanitizeBracketedPasteText, wrapTerminalBracketedPasteText } from './bracketed-paste-text'
+import {
+  imagePasteWritesFollowedByText,
+  separateImagePasteFromFollowingText
+} from './image-paste-following-text'
+import type { NativeChatAttachmentForm } from './native-chat-agent-profiles'
+
+/** True when the draft spans more than one line (so it needs bracketed-paste
+ *  wrapping). A trailing newline alone still counts as multi-line. */
+export function isMultilineDraft(text: string): boolean {
+  return /[\r\n]/.test(text)
+}
+
+/**
+ * Compute the bytes for `text` WITHOUT the trailing submit:
+ *  - single-line → `text`
+ *  - multi-line  → `\x1b[200~…\x1b[201~` (bracketed-paste wrapped, no submit)
+ *
+ * Why split the submit out: agent TUIs treat a framed paste that carries a
+ * trailing `\r` in the SAME pty write as part of the paste body rather than an
+ * Enter, so the text lands in the input box but never sends. Callers write this
+ * body first, then write the submit as a separate, slightly-delayed write
+ * (mirrors orca-runtime's writeTerminalAction Enter handling).
+ */
+export function buildNativeChatPasteBytes(text: string): string {
+  if (isMultilineDraft(text)) {
+    return wrapTerminalBracketedPasteText(text)
+  }
+  // Why: sanitize even unframed text so pasted scrollback cannot carry a raw
+  // terminal escape into the agent composer.
+  return sanitizeBracketedPasteText(text)
+}
+
+export function formatNativeChatFileReference(filePath: string): string {
+  const escaped = filePath.replace(/"/g, '\\"')
+  return /\s/.test(filePath) ? `@"${escaped}"` : `@${filePath}`
+}
+
+/**
+ * One attachment's bytes, in the form its agent understands:
+ *  - `image-paste` → bracketed paste of the raw path. Claude/Codex/Grok TUIs
+ *    detect that gesture and attach the file as an image; a plain typed path (or
+ *    @file mention) would be treated as text/file-read instead.
+ *  - `file-reference` → the portable `@path` mention. Agents with no verified
+ *    image-paste gesture would otherwise receive a naked path as prose.
+ */
+export function buildNativeChatAttachmentBytes(
+  filePath: string,
+  form: NativeChatAttachmentForm
+): string {
+  if (form === 'file-reference') {
+    // Why: an unframed write is keystrokes, so a filename holding CR/LF would
+    // submit the turn early. buildNativeChatPasteBytes already frames those.
+    return buildNativeChatPasteBytes(formatNativeChatFileReference(filePath))
+  }
+  return wrapTerminalBracketedPasteText(filePath)
+}
+
+/** The per-attachment PTY writes for a send. Bracketed image frames are
+ *  self-delimiting, so only the last needs a space before prompt text; `@path`
+ *  references are plain text and need one between every pair as well. */
+export function buildNativeChatAttachmentWrites(
+  filePaths: readonly string[],
+  form: NativeChatAttachmentForm,
+  followedByText: boolean
+): string[] {
+  const payloads = filePaths.map((filePath) => buildNativeChatAttachmentBytes(filePath, form))
+  if (form === 'image-paste') {
+    return imagePasteWritesFollowedByText(payloads, followedByText)
+  }
+  return payloads.map((payload, index) =>
+    separateImagePasteFromFollowingText(payload, index < payloads.length - 1 || followedByText)
+  )
+}


### PR DESCRIPTION
## ELI5

Desktop already picks the attachment form each agent actually accepts. Mobile's native chat still sent every agent the same thing, so an agent without an image-paste gesture got a bare path where it should have got a file reference. This makes mobile use the same rule instead of keeping its own.

## What Changed

- Mobile's native-chat send path now builds its attachment writes with the shared `buildNativeChatAttachmentWrites`, keyed by the existing `getNativeChatAttachmentForm` — no third per-agent table.
- Extracts the pure byte/framing primitives into `src/shared/bracketed-paste-text.ts` and `src/shared/native-chat-paste-bytes.ts`. The desktop helpers were renderer-bound (`native-chat-send.ts` pulled in `native-chat-composer-target.ts`, which imports renderer i18n/runtime, and `terminal-bracketed-paste.ts` is xterm-bound), so mobile could not import them. Both renderer modules now re-export from the shared modules, so no desktop caller changed.
- The agent is read at send time from the chat tab's existing `activeChatAgentRef`, like mobile's other send paths.
- A third commit hardens the shared module: a `@path` reference whose name holds a quote is now quoted (escaping only makes sense inside a quoted token), and a reference holding TAB or another C0 byte is framed instead of being written as keystrokes. ESC stays unframed but sanitized, which is the pre-existing deliberate behaviour.

## Why

Same root cause as #20389 — the attachment form was uniform per agent. Reusing the shared rule rather than copying it is also what keeps desktop and mobile from drifting on this again.

## Linked Issue

Part of #20389. Stacked on #20390, which fixes the desktop path.

## Visual Proof

N/A — this changes the PTY bytes written for an attachment, not any rendered UI. There is no visual or interaction change.

## Testing

- `mobile/`: `pnpm test` → 510 files, 4175 passed, 3 skipped. `pnpm typecheck` (tsc --noEmit) clean. `pnpm lint` (oxlint) exit 0.
- Root: native-chat + terminal-pane + shared suites pass; `pnpm tc:web` and `pnpm tc:node` clean; `pnpm run check:code-quality:changed` reports 0 new findings.
- A direct test file was added for `src/shared/native-chat-paste-bytes.ts`, which previously had none, covering the quoting rule, the framing boundary, and both attachment forms.
- Platform notes: byte construction only; no new path handling or platform branches. Worth knowing for review: **mobile's tsconfig excludes test files**, so mobile test files are not typechecked — a review pass caught a missing required argument in a new test that `tsc` did not.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Opus 5), running as an Orca-supervised worker. Reviewed by a six-reviewer pass (correctness, project standards, testing, maintainability, frontend-races, plus an independent cross-model adversarial review), and independently verified by the coordinating agent, which re-ran the mobile and root gates against this tree.

## Review

### Stacking

This branch is stacked on #20390 — its first commit **is** that PR's commit, so review #20390 first. Both PRs target `main` rather than chaining bases, because the stacked branch lives in a fork and cannot be used as a base branch upstream; once #20390 merges, this diff collapses to the mobile commit plus the hardening commit.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: byte construction only; no new IPC, no new dependency.
- Cross-platform: identical construction on macOS, Linux and Windows.
- SSH/remote: unchanged — mobile reuses the existing send path.
- Mobile: this is the mobile parity change for #20389.
- Backwards compatibility: no desktop caller changed; the shared modules are re-exported from their previous homes.
- Performance: the write count per send is unchanged, so the existing mobile sequence deadline still funds a whole send.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
