### PR TITLE
fix(sidebar): keep Hide default branch on when adding a project

### DIFF
--- a/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.test.tsx
@@ -18,7 +18,6 @@ const mocks = vi.hoisted(() => ({
     openModal: vi.fn(),
     addRepoPath: vi.fn(),
     fetchWorktrees: vi.fn(),
-    setHideDefaultBranchWorkspace: vi.fn(),
     clearOrcaHookTrustForRepo: vi.fn(),
     repos: [] as Repo[]
   },
@@ -162,8 +161,7 @@ describe('AddProjectFromFolderDialog', () => {
       source: 'local_folder_picker',
       selectedPath: '/projects/child',
       executionHostId: 'local',
-      closeModal: mocks.state.closeModal,
-      setHideDefaultBranchWorkspace: mocks.state.setHideDefaultBranchWorkspace
+      closeModal: mocks.state.closeModal
     })
     expect(mocks.state.openModal).not.toHaveBeenCalledWith(
       'confirm-non-git-folder',
@@ -214,8 +212,7 @@ describe('AddProjectFromFolderDialog', () => {
       source: 'runtime_server_path',
       selectedPath: '/srv/projects/child',
       executionHostId: 'runtime:runtime-a',
-      closeModal: mocks.state.closeModal,
-      setHideDefaultBranchWorkspace: mocks.state.setHideDefaultBranchWorkspace
+      closeModal: mocks.state.closeModal
     })
   })
 
@@ -245,8 +242,7 @@ describe('AddProjectFromFolderDialog', () => {
       source: 'ssh_remote_path',
       selectedPath: '/srv/projects/child',
       executionHostId: 'ssh:ssh-target-1',
-      closeModal: mocks.state.closeModal,
-      setHideDefaultBranchWorkspace: mocks.state.setHideDefaultBranchWorkspace
+      closeModal: mocks.state.closeModal
     })
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Project added on SSH host', {
       description: repo.displayName
@@ -271,8 +267,7 @@ describe('AddProjectFromFolderDialog', () => {
       source: 'local_folder_picker',
       selectedPath: '/projects/child',
       executionHostId: 'local',
-      closeModal: mocks.state.closeModal,
-      setHideDefaultBranchWorkspace: mocks.state.setHideDefaultBranchWorkspace
+      closeModal: mocks.state.closeModal
     })
   })
 

--- a/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
@@ -28,7 +28,6 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
   const openModal = useAppStore((s) => s.openModal)
   const addRepoPath = useAppStore((s) => s.addRepoPath)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
-  const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
 
   const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -128,8 +127,7 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
             : 'local_folder_picker',
         selectedPath: folderPath,
         executionHostId: ownerOptions.executionHostId,
-        closeModal,
-        setHideDefaultBranchWorkspace
+        closeModal
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -156,8 +154,7 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
     isAdding,
     mountedRef,
     openNonGitConfirmation,
-    runtimeEnvironmentId,
-    setHideDefaultBranchWorkspace
+    runtimeEnvironmentId
   ])
 
   const handleOpenChange = useCallback(

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -37,7 +37,6 @@ export default React.memo(function AddRepoDialog({
   const importNestedRepos = useAppStore((s) => s.importNestedRepos)
   const repos = useAppStore((s) => s.repos)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
-  const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
   const settings = useAppStore((s) => s.settings)
   const { closeModal, closeForFolderHandoff, finishProjectAdd, handleOpenSshSettings } =
     useAddRepoHostedController(hosted)
@@ -46,7 +45,6 @@ export default React.memo(function AddRepoDialog({
   const [addProjectBusyLabel, setAddProjectBusyLabel] = useState<string | null>(null)
   const completeGitRepoAdd = useCompleteGitRepoAdd({
     closeModal,
-    setHideDefaultBranchWorkspace,
     finishProjectAdd
   })
   const hostSelection = useAddRepoHostSelection({ isOpen, setStep })

--- a/src/renderer/src/components/sidebar/ProjectAddedDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/ProjectAddedDialog.test.tsx
@@ -11,8 +11,7 @@ const mocks = vi.hoisted(() => ({
     repos: [] as Repo[],
     worktreesByRepo: {} as Record<string, unknown[]>,
     fetchRepos: vi.fn(),
-    fetchWorktrees: vi.fn(),
-    setHideDefaultBranchWorkspace: vi.fn()
+    fetchWorktrees: vi.fn()
   },
   activateAndRevealWorktree: vi.fn(),
   finishProjectAddWithDefaultCheckout: vi.fn()
@@ -83,8 +82,7 @@ describe('ProjectAddedDialog', () => {
     expect(mocks.finishProjectAddWithDefaultCheckout).toHaveBeenCalledWith({
       repoId: 'repo-1',
       source: 'project_added_compat',
-      closeModal: mocks.state.closeModal,
-      setHideDefaultBranchWorkspace: mocks.state.setHideDefaultBranchWorkspace
+      closeModal: mocks.state.closeModal
     })
   })
 
@@ -115,8 +113,7 @@ describe('ProjectAddedDialog', () => {
     expect(mocks.finishProjectAddWithDefaultCheckout).toHaveBeenCalledWith({
       repoId: 'repo-1',
       source: 'project_added_compat',
-      closeModal: mocks.state.closeModal,
-      setHideDefaultBranchWorkspace: mocks.state.setHideDefaultBranchWorkspace
+      closeModal: mocks.state.closeModal
     })
   })
 

--- a/src/renderer/src/components/sidebar/ProjectAddedDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectAddedDialog.tsx
@@ -16,7 +16,6 @@ export default function ProjectAddedDialog(): null {
   const repos = useAppStore((s) => s.repos)
   const fetchRepos = useAppStore((s) => s.fetchRepos)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
-  const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
   const handoffRunRef = useRef(0)
   const pendingRepoHydrationRef = useRef<string | null>(null)
 
@@ -101,23 +100,14 @@ export default function ProjectAddedDialog(): null {
         await finishProjectAddWithDefaultCheckout({
           repoId,
           source: 'project_added_compat',
-          closeModal,
-          setHideDefaultBranchWorkspace
+          closeModal
         })
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [
-    activeModal,
-    closeModal,
-    fetchRepos,
-    fetchWorktrees,
-    repo,
-    repoId,
-    setHideDefaultBranchWorkspace
-  ])
+  }, [activeModal, closeModal, fetchRepos, fetchWorktrees, repo, repoId])
 
   return null
 }

--- a/src/renderer/src/components/sidebar/WorktreeList.empty-project-rows.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.empty-project-rows.test.ts
@@ -18,7 +18,8 @@ import {
 import {
   makeFolderWorkspacePathStatusMockState,
   makeFolderWorkspacePathStatusState,
-  makeRepo
+  makeRepo,
+  makeWorktree
 } from './worktree-list-lineage-card-test-fixtures'
 
 vi.mock('@/store', () => createAppStoreModuleMock())
@@ -94,6 +95,25 @@ function setEmptyUngroupedProjectState(filterRepoIds: string[] = []): void {
   }
 }
 
+function setHiddenDefaultCheckoutProjectState(): void {
+  setEmptyUngroupedProjectState()
+  mockStore.state.hideDefaultBranchWorkspace = true
+  mockStore.state.worktreesByRepo = {
+    'repo-1': [
+      {
+        ...makeWorktree({
+          id: 'repo-1::/tmp/lineage-order',
+          displayName: 'main',
+          branch: 'refs/heads/main',
+          sortOrder: 1,
+          instanceId: 'main'
+        }),
+        isMainWorktree: true
+      }
+    ]
+  }
+}
+
 // Why: describe title is shared across the split files so test full names stay stable.
 describe('WorktreeList lineage child card renderer', () => {
   beforeAll(async () => {
@@ -122,5 +142,14 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(markup).toContain('No workspaces found')
     expect(markup).toContain('Clear Filters')
     expect(markup).not.toContain('empty-project')
+  })
+
+  it('keeps a default-checkout-only ungrouped project header under Hide default branch', async () => {
+    setHiddenDefaultCheckoutProjectState()
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('empty-project')
+    expect(markup).not.toContain('data-worktree-card-id')
+    expect(markup).not.toContain('No workspaces found')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -171,6 +171,7 @@ const WorktreeList = React.memo(function WorktreeList({
     importedWorktreesByRepo: externalWorktreeCards.importedWorktreesByRepo,
     newExternalWorktreesInboxByRepo: externalWorktreeCards.newExternalWorktreesInboxByRepo,
     filterRepoIds: filterState.filterRepoIds,
+    hideDefaultBranchWorkspace: filterState.hideDefaultBranchWorkspace,
     visibleWorkspaceHostIds: filterState.visibleWorkspaceHostIds,
     workspaceHostScope: filterState.workspaceHostScope
   })

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
@@ -28,7 +28,13 @@ function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: strin
   }
 }
 
-function makeState(overrides: Partial<AddRepoSkipFinalizationState>): AddRepoSkipFinalizationState {
+// Why keep a setter the contract dropped: a ratchet against re-introducing the filter
+// flip that silently overrode the user's "Hide default branch" choice.
+type SkipFinalizationTestState = AddRepoSkipFinalizationState & {
+  setHideDefaultBranchWorkspace: ReturnType<typeof vi.fn>
+}
+
+function makeState(overrides: Partial<SkipFinalizationTestState>): SkipFinalizationTestState {
   return {
     activeRepoId: null,
     filterRepoIds: [],
@@ -66,7 +72,7 @@ describe('finalizeImportedRepoAfterSkip', () => {
     expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
   })
 
-  it('clears default-branch hiding when it would hide every imported worktree', () => {
+  it('keeps default-branch hiding on when the import is only a default checkout', () => {
     const state = makeState({
       hideDefaultBranchWorkspace: true,
       worktreesByRepo: {
@@ -83,7 +89,54 @@ describe('finalizeImportedRepoAfterSkip', () => {
 
     finalizeImportedRepoAfterSkip(state, 'repo-new')
 
-    expect(state.setHideDefaultBranchWorkspace).toHaveBeenCalledWith(false)
+    expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+    expect(state.setActiveRepo).toHaveBeenCalledWith('repo-new')
+  })
+
+  it('leaves the sleeping exemption alone when Hide default branch already hides the import', () => {
+    const state = makeState({
+      showSleepingWorkspaces: false,
+      alwaysShowDefaultBranchWorkspace: false,
+      hideDefaultBranchWorkspace: true,
+      worktreesByRepo: {
+        'repo-new': [
+          makeWorktree({
+            id: 'repo-new::/repo/main',
+            repoId: 'repo-new',
+            isMainWorktree: true,
+            branch: 'refs/heads/main'
+          })
+        ]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setAlwaysShowDefaultBranchWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('still exempts a branchless main import from the sleeping sweep while Hide default branch is on', () => {
+    // Why: the filter only hides rows that pass isDefaultBranchWorkspace, so a
+    // detached-HEAD main is not hidden by it and still needs the sweep exemption.
+    const state = makeState({
+      showSleepingWorkspaces: false,
+      alwaysShowDefaultBranchWorkspace: false,
+      hideDefaultBranchWorkspace: true,
+      worktreesByRepo: {
+        'repo-new': [
+          makeWorktree({
+            id: 'repo-new::/repo/main',
+            repoId: 'repo-new',
+            isMainWorktree: true,
+            branch: ''
+          })
+        ]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setAlwaysShowDefaultBranchWorkspace).toHaveBeenCalledWith(true)
   })
 
   it('re-enables the default-branch exemption when the import would land asleep and hidden', () => {

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -5,6 +5,8 @@ export type AddRepoSkipFinalizationState = {
   activeRepoId: string | null
   filterRepoIds: readonly string[]
   showActiveOnly: boolean
+  /** Read, never reset: empty-project-placeholder-repos keeps a header for a
+   *  default-checkout-only project, so the import still lands visibly. */
   hideDefaultBranchWorkspace: boolean
   showSleepingWorkspaces: boolean
   alwaysShowDefaultBranchWorkspace: boolean
@@ -12,7 +14,6 @@ export type AddRepoSkipFinalizationState = {
   setActiveRepo: (repoId: string | null) => void
   setFilterRepoIds: (repoIds: string[]) => void
   setShowActiveOnly: (value: boolean) => void
-  setHideDefaultBranchWorkspace: (value: boolean) => void
   setAlwaysShowDefaultBranchWorkspace: (value: boolean) => void
 }
 
@@ -33,17 +34,16 @@ export function finalizeImportedRepoAfterSkip(
   if (state.showActiveOnly) {
     state.setShowActiveOnly(false)
   }
-  if (
-    importedWorktrees.length > 0 &&
-    state.hideDefaultBranchWorkspace &&
-    importedWorktrees.every((worktree) => isDefaultBranchWorkspace(worktree))
-  ) {
-    state.setHideDefaultBranchWorkspace(false)
-  }
   // Why: with "Hide sleeping" on, a freshly imported project has no live PTY
   // yet, so the opted-out exemption would leave it invisible on arrival.
+  // Rows the default-branch filter already hides stay hidden either way, so
+  // the exemption is only flipped for imports that filter leaves visible.
+  const hiddenByDefaultBranchFilter =
+    state.hideDefaultBranchWorkspace &&
+    importedWorktrees.every((worktree) => isDefaultBranchWorkspace(worktree))
   if (
     importedWorktrees.length > 0 &&
+    !hiddenByDefaultBranchFilter &&
     state.alwaysShowDefaultBranchWorkspace === false &&
     !state.showSleepingWorkspaces &&
     importedWorktrees.every((worktree) => worktree.isMainWorktree)

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
@@ -40,7 +40,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [repo],
           worktreesByRepo: { [repo.id]: [] },
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          hideDefaultBranchWorkspace: false
         })
       )
     ).toEqual([repo.id])
@@ -54,7 +55,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [repo],
           worktreesByRepo: {},
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          hideDefaultBranchWorkspace: false
         })
       )
     ).toEqual([repo.id])
@@ -71,7 +73,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [selectedRepo, hiddenRepo],
           worktreesByRepo: { [selectedRepo.id]: [], [hiddenRepo.id]: [] },
           visibleWorktrees: [],
-          filterRepoIds: [selectedRepo.id]
+          filterRepoIds: [selectedRepo.id],
+          hideDefaultBranchWorkspace: false
         })
       )
     ).toEqual([selectedRepo.id])
@@ -84,7 +87,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         repos: [repo],
         worktreesByRepo: { [repo.id]: [] },
         visibleWorktrees: [],
-        filterRepoIds: []
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: false
       }).size
     ).toBe(0)
   })
@@ -96,7 +100,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         repos: [repo],
         worktreesByRepo: { [repo.id]: [worktree] },
         visibleWorktrees: [],
-        filterRepoIds: []
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: false
       }).size
     ).toBe(0)
   })
@@ -112,7 +117,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [groupedRepo],
           worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          hideDefaultBranchWorkspace: false
         })
       )
     ).toEqual([groupedRepo.id])
@@ -128,7 +134,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         repos: [groupedRepo],
         worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
         visibleWorktrees: [groupedWorktree],
-        filterRepoIds: []
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: false
       }).size
     ).toBe(0)
   })
@@ -151,7 +158,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           // Why: simulate Hide sleeping removing every card while the project
           // filter still intentionally excludes `filteredOut`.
           visibleWorktrees: [],
-          filterRepoIds: [selected.id]
+          filterRepoIds: [selected.id],
+          hideDefaultBranchWorkspace: false
         })
       )
     ).toEqual([selected.id])
@@ -173,7 +181,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
             [awake.id]: [awakeWt]
           },
           visibleWorktrees: [awakeWt],
-          filterRepoIds: []
+          filterRepoIds: [],
+          hideDefaultBranchWorkspace: false
         })
       )
     ).toEqual([sleeping.id])
@@ -195,9 +204,132 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
             [ungrouped.id]: [ungroupedWt]
           },
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          hideDefaultBranchWorkspace: false
         })
       )
     ).toEqual([grouped.id])
+  })
+
+  it('does not create placeholders outside repo grouping even under Hide default branch', () => {
+    expect(
+      getEmptyProjectPlaceholderRepoIds({
+        groupBy: 'none',
+        repos: [repo],
+        worktreesByRepo: { [repo.id]: [worktree] },
+        visibleWorktrees: [],
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: true
+      }).size
+    ).toBe(0)
+  })
+
+  it('does not placeholder a provisioned-root checkout, which the filter leaves visible', () => {
+    expect(
+      getEmptyProjectPlaceholderRepoIds({
+        groupBy: 'repo',
+        repos: [repo],
+        worktreesByRepo: {
+          [repo.id]: [{ ...worktree, ephemeralVmCheckoutMode: 'provisioned-root' }]
+        },
+        visibleWorktrees: [],
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: true
+      }).size
+    ).toBe(0)
+  })
+
+  it('keeps an ungrouped repo visible when Hide default branch hides its only checkout', () => {
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [repo],
+          worktreesByRepo: { [repo.id]: [worktree] },
+          visibleWorktrees: [],
+          filterRepoIds: [],
+          hideDefaultBranchWorkspace: true
+        })
+      )
+    ).toEqual([repo.id])
+  })
+
+  it('ignores archived rows when deciding a repo is default-checkout-only', () => {
+    const archivedFeature: Worktree = {
+      ...worktree,
+      id: 'wt-archived',
+      branch: 'refs/heads/feature',
+      isMainWorktree: false,
+      isArchived: true
+    }
+
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [repo],
+          worktreesByRepo: { [repo.id]: [worktree, archivedFeature] },
+          visibleWorktrees: [],
+          filterRepoIds: [],
+          hideDefaultBranchWorkspace: true
+        })
+      )
+    ).toEqual([repo.id])
+  })
+
+  it('does not placeholder a repo whose non-default rows are hidden by other filters', () => {
+    const feature: Worktree = {
+      ...worktree,
+      id: 'wt-feature',
+      branch: 'refs/heads/feature',
+      isMainWorktree: false
+    }
+
+    // Why: one non-default row disqualifies the repo — the placeholder is for
+    // default-checkout-only projects, not for any repo whose rows a filter hid.
+    expect(
+      getEmptyProjectPlaceholderRepoIds({
+        groupBy: 'repo',
+        repos: [repo],
+        worktreesByRepo: { [repo.id]: [worktree, feature] },
+        visibleWorktrees: [],
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: true
+      }).size
+    ).toBe(0)
+  })
+
+  it('does not placeholder a default-checkout-only repo while one of its rows is visible', () => {
+    expect(
+      getEmptyProjectPlaceholderRepoIds({
+        groupBy: 'repo',
+        repos: [repo],
+        worktreesByRepo: { [repo.id]: [worktree] },
+        visibleWorktrees: [worktree],
+        filterRepoIds: [],
+        hideDefaultBranchWorkspace: true
+      }).size
+    ).toBe(0)
+  })
+
+  it('applies repo filters to default-checkout-only placeholder candidates', () => {
+    const selectedRepo = { ...repo, id: 'repo-selected' }
+    const hiddenRepo = { ...repo, id: 'repo-hidden' }
+
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [selectedRepo, hiddenRepo],
+          worktreesByRepo: {
+            [selectedRepo.id]: [{ ...worktree, id: 'wt-selected', repoId: selectedRepo.id }],
+            [hiddenRepo.id]: [{ ...worktree, id: 'wt-hidden', repoId: hiddenRepo.id }]
+          },
+          visibleWorktrees: [],
+          filterRepoIds: [selectedRepo.id],
+          hideDefaultBranchWorkspace: true
+        })
+      )
+    ).toEqual([selectedRepo.id])
   })
 })

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
@@ -1,6 +1,7 @@
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { WorktreeGroupBy } from './worktree-list/grouping/row-types'
+import { isDefaultBranchWorkspace } from './default-branch-workspace'
 
 export function getEmptyProjectPlaceholderRepoIds(args: {
   groupBy: WorktreeGroupBy
@@ -8,6 +9,7 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
   worktreesByRepo: Readonly<Record<string, readonly Worktree[] | undefined>>
   visibleWorktrees: readonly Worktree[]
   filterRepoIds: readonly string[]
+  hideDefaultBranchWorkspace: boolean
 }): Set<string> {
   if (args.groupBy !== 'repo') {
     return new Set()
@@ -24,9 +26,22 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
     // Why: workspace filters hide cards, but must not rewrite the visible
     // membership of a persisted Project Group. #8865
     const isFilteredProjectGroupMember = repo.projectGroupId != null && !visibleRepoIds.has(repo.id)
-    if (hasNoWorktrees || isFilteredProjectGroupMember) {
+    // Why: "Hide default branch" hides rows, not projects — every repo whose only
+    // live rows are default checkouts keeps a header, which is what lets the
+    // add-project handoff reveal an import without flipping the user's filter.
+    const isHiddenDefaultCheckoutOnly =
+      args.hideDefaultBranchWorkspace &&
+      !visibleRepoIds.has(repo.id) &&
+      hasOnlyDefaultCheckoutRows(args.worktreesByRepo[repo.id])
+    if (hasNoWorktrees || isFilteredProjectGroupMember || isHiddenDefaultCheckoutOnly) {
       placeholderRepoIds.add(repo.id)
     }
   }
   return placeholderRepoIds
+}
+
+// Why skip archived rows (unlike hasNoWorktrees): the sidebar drops them before any filter, so they never count as a live row.
+function hasOnlyDefaultCheckoutRows(worktrees: readonly Worktree[] | undefined): boolean {
+  const liveWorktrees = (worktrees ?? []).filter((worktree) => !worktree.isArchived)
+  return liveWorktrees.length > 0 && liveWorktrees.every(isDefaultBranchWorkspace)
 }

--- a/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
@@ -18,6 +18,8 @@ const mocks = vi.hoisted(() => ({
     filterRepoIds: [] as string[],
     showActiveOnly: false,
     hideDefaultBranchWorkspace: false,
+    showSleepingWorkspaces: true,
+    alwaysShowDefaultBranchWorkspace: true,
     repos: [] as Repo[],
     worktreesByRepo: {} as Record<string, Worktree[]>,
     detectedWorktreesByRepo: {} as Record<string, DetectedWorktreeListResult>,
@@ -25,10 +27,13 @@ const mocks = vi.hoisted(() => ({
     setFilterRepoIds: vi.fn(),
     setShowActiveOnly: vi.fn(),
     setHideDefaultBranchWorkspace: vi.fn(),
+    setAlwaysShowDefaultBranchWorkspace: vi.fn(),
+    revealSidebarRow: vi.fn(),
     updateRepo: vi.fn(),
     fetchWorktrees: vi.fn()
   },
   activateAndRevealWorktree: vi.fn(),
+  toastWarning: vi.fn(),
   onboardingGet: vi.fn(),
   onboardingUpdate: vi.fn(),
   track: vi.fn()
@@ -46,6 +51,14 @@ vi.mock('@/lib/worktree-activation', () => ({
 
 vi.mock('@/lib/telemetry', () => ({
   track: mocks.track
+}))
+
+vi.mock('sonner', () => ({
+  toast: { warning: mocks.toastWarning }
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
 }))
 
 function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
@@ -127,6 +140,8 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     mocks.state.filterRepoIds = []
     mocks.state.showActiveOnly = false
     mocks.state.hideDefaultBranchWorkspace = false
+    mocks.state.showSleepingWorkspaces = true
+    mocks.state.alwaysShowDefaultBranchWorkspace = true
     mocks.state.repos = []
     mocks.state.worktreesByRepo = {}
     mocks.state.detectedWorktreesByRepo = {}
@@ -146,8 +161,6 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
   it('closes the modal and activates the default checkout', async () => {
     const closeModal = vi.fn()
-    const setHideDefaultBranchWorkspace = vi.fn()
-    mocks.state.hideDefaultBranchWorkspace = true
     mocks.state.worktreesByRepo = {
       'repo-1': [makeWorktree()]
     }
@@ -155,15 +168,13 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     await finishProjectAddWithDefaultCheckout({
       repoId: 'repo-1',
       source: 'clone_url',
-      closeModal,
-      setHideDefaultBranchWorkspace
+      closeModal
     })
 
     expect(closeModal).toHaveBeenCalledTimes(1)
     expect(mocks.onboardingUpdate).toHaveBeenCalledWith({
       checklist: { addedRepo: true }
     })
-    expect(setHideDefaultBranchWorkspace).toHaveBeenCalledWith(false)
     expect(mocks.track).toHaveBeenCalledWith('activation_checklist_item_completed', {
       item: 'addedRepo',
       time_since_completed_ms: 0
@@ -174,6 +185,130 @@ describe('finishProjectAddWithDefaultCheckout', () => {
       reason: 'loaded_default_checkout'
     })
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::/repo')
+  })
+
+  it('reveals the project instead of opening a default checkout hidden by Hide default branch', async () => {
+    const closeModal = vi.fn()
+    mocks.state.hideDefaultBranchWorkspace = true
+    mocks.state.worktreesByRepo = {
+      'repo-1': [makeWorktree()]
+    }
+
+    await finishProjectAddWithDefaultCheckout({
+      repoId: 'repo-1',
+      source: 'clone_url',
+      closeModal
+    })
+
+    expect(closeModal).toHaveBeenCalledTimes(1)
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(mocks.state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+    expect(mocks.state.setActiveRepo).toHaveBeenCalledWith('repo-1')
+    expect(mocks.track).toHaveBeenCalledWith('add_repo_default_checkout_handoff', {
+      source: 'clone_url',
+      result: 'revealed_project',
+      reason: 'default_checkout_hidden'
+    })
+    // Why: outside project grouping there is no header row, so the reveal request is
+    // what switches grouping and scrolls to the new project.
+    expect(mocks.state.revealSidebarRow).toHaveBeenCalledWith(
+      'repo:repo-1',
+      expect.objectContaining({ highlight: true })
+    )
+    expect(mocks.toastWarning).not.toHaveBeenCalled()
+  })
+
+  it('opens a hidden default checkout anyway when the user picked a folder inside it', async () => {
+    mocks.state.hideDefaultBranchWorkspace = true
+    mocks.state.worktreesByRepo = {
+      'repo-1': [makeWorktree()]
+    }
+
+    await openProjectDefaultCheckout({
+      repoId: 'repo-1',
+      source: 'local_folder_picker',
+      selectedPath: '/repo/packages/web'
+    })
+
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::/repo', {
+      initialCwd: '/repo/packages/web'
+    })
+    expect(mocks.state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+    expect(mocks.state.revealSidebarRow).not.toHaveBeenCalled()
+    expect(mocks.toastWarning).toHaveBeenCalledTimes(1)
+    expect(mocks.track).toHaveBeenCalledWith('add_repo_default_checkout_handoff', {
+      source: 'local_folder_picker',
+      result: 'opened_default_checkout',
+      reason: 'loaded_default_checkout'
+    })
+  })
+
+  it('leaves both the filter and the sleeping exemption alone when Hide sleeping is also on', async () => {
+    mocks.state.hideDefaultBranchWorkspace = true
+    mocks.state.showSleepingWorkspaces = false
+    mocks.state.alwaysShowDefaultBranchWorkspace = false
+    mocks.state.worktreesByRepo = {
+      'repo-1': [makeWorktree()]
+    }
+
+    await openProjectDefaultCheckout({ repoId: 'repo-1', source: 'clone_url' })
+
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(mocks.state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+    expect(mocks.state.setAlwaysShowDefaultBranchWorkspace).not.toHaveBeenCalled()
+    expect(mocks.track).toHaveBeenCalledWith('add_repo_default_checkout_handoff', {
+      source: 'clone_url',
+      result: 'revealed_project',
+      reason: 'default_checkout_hidden'
+    })
+  })
+
+  it('reveals only once when colliding repo IDs share a hidden default checkout', async () => {
+    mocks.state.hideDefaultBranchWorkspace = true
+    mocks.state.worktreesByRepo = {
+      'repo-1': [
+        makeWorktree({ id: 'repo-1::same-id', path: '/local/repo', hostId: 'local' }),
+        makeWorktree({ id: 'repo-1::same-id', path: '/runtime/repo', hostId: 'runtime:env-1' })
+      ]
+    }
+
+    await openProjectDefaultCheckout({
+      repoId: 'repo-1',
+      source: 'runtime_server_path',
+      executionHostId: 'runtime:env-1'
+    })
+
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(mocks.state.setActiveRepo).toHaveBeenCalledWith('repo-1')
+    expect(
+      mocks.track.mock.calls.filter(([event]) => event === 'add_repo_default_checkout_handoff')
+    ).toHaveLength(1)
+  })
+
+  it('still opens a provisioned-root default checkout while Hide default branch is on', async () => {
+    mocks.state.hideDefaultBranchWorkspace = true
+    mocks.state.worktreesByRepo = {
+      'repo-1': [makeWorktree({ ephemeralVmCheckoutMode: 'provisioned-root' })]
+    }
+
+    await openProjectDefaultCheckout({ repoId: 'repo-1', source: 'clone_url' })
+
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::/repo')
+    expect(mocks.state.revealSidebarRow).not.toHaveBeenCalled()
+  })
+
+  it('still opens a detached-HEAD default checkout while Hide default branch is on', async () => {
+    mocks.state.hideDefaultBranchWorkspace = true
+    mocks.state.worktreesByRepo = {
+      'repo-1': [makeWorktree({ branch: '' })]
+    }
+
+    await openProjectDefaultCheckout({ repoId: 'repo-1', source: 'clone_url' })
+
+    // Why: the filter only hides rows that pass isDefaultBranchWorkspace, so a
+    // branchless main row is visible and the handoff can land on it.
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::/repo')
+    expect(mocks.state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
   })
 
   it('activates only the captured host default checkout when repo IDs collide', async () => {
@@ -212,8 +347,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
       source: 'clone_url',
-      executionHostId: 'runtime:env-1',
-      setHideDefaultBranchWorkspace: vi.fn()
+      executionHostId: 'runtime:env-1'
     })
 
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(runtimeMain.id, {
@@ -232,8 +366,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
       source: 'runtime_server_path',
-      executionHostId: 'runtime:env-1',
-      setHideDefaultBranchWorkspace: vi.fn()
+      executionHostId: 'runtime:env-1'
     })
 
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(runtimeMain.id, {
@@ -249,8 +382,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
       source: 'local_folder_picker',
-      selectedPath: '/repo/packages/web',
-      setHideDefaultBranchWorkspace: vi.fn()
+      selectedPath: '/repo/packages/web'
     })
 
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::/repo', {
@@ -266,8 +398,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
       source: 'local_folder_picker',
-      selectedPath: '/repo',
-      setHideDefaultBranchWorkspace: vi.fn()
+      selectedPath: '/repo'
     })
 
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::/repo')
@@ -299,8 +430,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'local_folder_picker',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'local_folder_picker'
     })
 
     expect(mocks.state.updateRepo).toHaveBeenCalledWith('repo-1', {
@@ -328,8 +458,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'local_folder_picker',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'local_folder_picker'
     })
 
     expect(mocks.state.updateRepo).toHaveBeenCalledWith('repo-1', {
@@ -357,8 +486,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'local_folder_picker',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'local_folder_picker'
     })
 
     expect(mocks.state.updateRepo).not.toHaveBeenCalled()
@@ -382,8 +510,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'local_folder_picker',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'local_folder_picker'
     })
 
     expect(mocks.state.updateRepo).not.toHaveBeenCalled()
@@ -419,8 +546,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'local_folder_picker',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'local_folder_picker'
     })
 
     expect(mocks.state.updateRepo).toHaveBeenCalledTimes(1)
@@ -448,8 +574,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'local_folder_picker',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'local_folder_picker'
     })
 
     expect(mocks.track).toHaveBeenCalledWith('add_repo_default_checkout_handoff', {
@@ -473,8 +598,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'local_folder_picker',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'local_folder_picker'
     })
 
     expect(mocks.track).toHaveBeenCalledWith('add_repo_default_checkout_handoff', {
@@ -488,7 +612,6 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
   it('reveals the project if no default checkout is available', async () => {
     const closeModal = vi.fn()
-    const setHideDefaultBranchWorkspace = vi.fn()
     mocks.state.worktreesByRepo = {
       'repo-1': [makeWorktree({ isMainWorktree: false })]
     }
@@ -496,8 +619,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     await finishProjectAddWithDefaultCheckout({
       repoId: 'repo-1',
       source: 'ssh_remote_path',
-      closeModal,
-      setHideDefaultBranchWorkspace
+      closeModal
     })
 
     expect(closeModal).toHaveBeenCalledTimes(1)
@@ -508,7 +630,6 @@ describe('finishProjectAddWithDefaultCheckout', () => {
       reason: 'no_authoritative_detection'
     })
     expect(mocks.state.setActiveRepo).toHaveBeenCalledWith('repo-1')
-    expect(setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
   })
 
   it('reveals the project even when no worktrees are loaded', async () => {
@@ -518,8 +639,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
 
     await openProjectDefaultCheckout({
       repoId: 'repo-1',
-      source: 'project_added_compat',
-      setHideDefaultBranchWorkspace: vi.fn()
+      source: 'project_added_compat'
     })
 
     expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()

--- a/src/renderer/src/components/sidebar/project-added-default-checkout.ts
+++ b/src/renderer/src/components/sidebar/project-added-default-checkout.ts
@@ -1,6 +1,10 @@
+import { toast } from 'sonner'
 import { useAppStore } from '@/store'
+import { getRepoMapFromState } from '@/store/selectors'
+import { getProjectHostSetupProjectionFromState } from '@/store/project-host-setup-selector'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { track } from '@/lib/telemetry'
+import { translate } from '@/i18n/i18n'
 import type {
   AddRepoDefaultCheckoutHandoffSource,
   EventProps
@@ -9,6 +13,8 @@ import type { DetectedWorktreeListResult, Worktree } from '../../../../shared/wo
 import { relativePathInsideRoot } from '../../../../shared/cross-platform-path'
 import { markOnboardingProjectAdded } from '@/lib/onboarding-project-checklist'
 import { finalizeImportedRepoAfterSkip } from './add-repo-skip-finalization'
+import { isDefaultBranchWorkspace } from './default-branch-workspace'
+import { getProjectHeaderRevealTarget } from './worktree-list/grouping/project-grouping'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 
 type DefaultCheckoutHandoffReason = EventProps<'add_repo_default_checkout_handoff'>['reason']
@@ -165,6 +171,18 @@ async function findDetectedDefaultCheckout(
   }
 }
 
+/** Lands on the project header: outside project grouping the reveal request is what switches grouping and scrolls there. */
+function revealImportedProject(repoId: string): void {
+  const state = useAppStore.getState()
+  finalizeImportedRepoAfterSkip(state, repoId)
+  const projection = getProjectHostSetupProjectionFromState(state)
+  const target = getProjectHeaderRevealTarget(repoId, getRepoMapFromState(state), {
+    projects: projection.projects,
+    projectHostSetups: projection.setups
+  })
+  state.revealSidebarRow(target.key, { behavior: 'smooth', highlight: true })
+}
+
 function resolveInitialCwdForDefaultCheckout(
   defaultCheckout: Worktree,
   selectedPath: string | undefined
@@ -180,13 +198,11 @@ export async function openProjectDefaultCheckout({
   repoId,
   source,
   selectedPath,
-  setHideDefaultBranchWorkspace,
   executionHostId
 }: {
   repoId: string
   source: AddRepoDefaultCheckoutHandoffSource
   selectedPath?: string
-  setHideDefaultBranchWorkspace: (value: boolean) => void
   executionHostId?: ExecutionHostId
 }): Promise<void> {
   let defaultCheckout = getProjectDefaultCheckout(
@@ -213,21 +229,29 @@ export async function openProjectDefaultCheckout({
         result: 'revealed_project',
         reason: revealLinkedFailureReason
       })
-      finalizeImportedRepoAfterSkip(useAppStore.getState(), repoId)
+      revealImportedProject(repoId)
       return
     }
-    // Why: the onboarding handoff should land on the default checkout even
-    // when the user normally hides default-branch workspaces in the sidebar.
-    const state = useAppStore.getState()
-    if (state.hideDefaultBranchWorkspace) {
-      setHideDefaultBranchWorkspace(false)
+    const initialCwd = resolveInitialCwdForDefaultCheckout(defaultCheckout, selectedPath)
+    const hiddenByDefaultBranchFilter =
+      useAppStore.getState().hideDefaultBranchWorkspace && isDefaultBranchWorkspace(defaultCheckout)
+    // Why: a user who hides default-branch rows opted out of landing on one, so
+    // reveal the project header instead of silently flipping their filter. A
+    // folder they picked inside the checkout was their real target and still opens.
+    if (hiddenByDefaultBranchFilter && !initialCwd) {
+      track('add_repo_default_checkout_handoff', {
+        source,
+        result: 'revealed_project',
+        reason: 'default_checkout_hidden'
+      })
+      revealImportedProject(repoId)
+      return
     }
     track('add_repo_default_checkout_handoff', {
       source,
       result: 'opened_default_checkout',
       reason
     })
-    const initialCwd = resolveInitialCwdForDefaultCheckout(defaultCheckout, selectedPath)
     if (initialCwd || executionHostId) {
       activateAndRevealWorktree(defaultCheckout.id, {
         ...(initialCwd ? { initialCwd } : {}),
@@ -235,6 +259,14 @@ export async function openProjectDefaultCheckout({
       })
     } else {
       activateAndRevealWorktree(defaultCheckout.id)
+    }
+    if (hiddenByDefaultBranchFilter) {
+      toast.warning(
+        translate(
+          'auto.lib.worktreeJumpNavigation.filteredNotice',
+          'This worktree is hidden by sidebar filters. The workspace was opened, but it is not shown in Spaces.'
+        )
+      )
     }
     return
   }
@@ -244,7 +276,7 @@ export async function openProjectDefaultCheckout({
     result: 'revealed_project',
     reason
   })
-  finalizeImportedRepoAfterSkip(useAppStore.getState(), repoId)
+  revealImportedProject(repoId)
 }
 
 export async function finishProjectAddWithDefaultCheckout({
@@ -252,14 +284,12 @@ export async function finishProjectAddWithDefaultCheckout({
   source,
   selectedPath,
   closeModal,
-  setHideDefaultBranchWorkspace,
   executionHostId
 }: {
   repoId: string
   source: AddRepoDefaultCheckoutHandoffSource
   selectedPath?: string
   closeModal: () => void
-  setHideDefaultBranchWorkspace: (value: boolean) => void
   executionHostId?: ExecutionHostId
 }): Promise<void> {
   await markOnboardingProjectAdded('addedRepo')
@@ -268,7 +298,6 @@ export async function finishProjectAddWithDefaultCheckout({
     repoId,
     source,
     selectedPath,
-    executionHostId,
-    setHideDefaultBranchWorkspace
+    executionHostId
   })
 }

--- a/src/renderer/src/components/sidebar/sidebar-filter-actions.ts
+++ b/src/renderer/src/components/sidebar/sidebar-filter-actions.ts
@@ -13,6 +13,8 @@ export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
   return (
     state.showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES ||
     state.filterRepoIds.length > 0 ||
+    // Why: outside repo grouping there is no project-header placeholder, so hiding
+    // the only default-branch row would strand the user with no Clear Filters path.
     state.hideDefaultBranchWorkspace ||
     state.hideAutomationGeneratedWorkspaces ||
     state.hideCliCreatedWorkspaces ||

--- a/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
+++ b/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
@@ -12,10 +12,10 @@ import type { ExecutionHostId } from '../../../../shared/execution-host'
 
 type CompleteGitRepoAddOptions = {
   closeModal: () => void
-  setHideDefaultBranchWorkspace: (hide: boolean) => void
   /** Why: the nested Add Project flow (hosted inside the workspace composer)
    *  keeps the composer open and selects the new project instead of running
-   *  the default-checkout navigation handoff. Telemetry above still applies. */
+   *  the default-checkout navigation handoff. The existing-workspaces telemetry
+   *  still fires either way. */
   finishProjectAdd?: (
     repoId: string,
     source: AddRepoExistingWorkspaceSource,
@@ -25,7 +25,6 @@ type CompleteGitRepoAddOptions = {
 
 export function useCompleteGitRepoAdd({
   closeModal,
-  setHideDefaultBranchWorkspace,
   finishProjectAdd
 }: CompleteGitRepoAddOptions): (
   repoId: string,
@@ -72,10 +71,9 @@ export function useCompleteGitRepoAdd({
         repoId,
         source,
         executionHostId,
-        closeModal,
-        setHideDefaultBranchWorkspace
+        closeModal
       })
     },
-    [closeModal, finishProjectAdd, setHideDefaultBranchWorkspace]
+    [closeModal, finishProjectAdd]
   )
 }

--- a/src/renderer/src/components/sidebar/visible-worktree-kinds.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-kinds.ts
@@ -62,13 +62,3 @@ export type SidebarFilterState = {
   visibleWorkspaceHostIds?: readonly ExecutionHostId[] | null
   workspaceHostScope?: ExecutionHostScope
 }
-
-/**
- * Whether at least one sidebar filter is active — drives the "Clear Filters"
- * escape hatch in the empty-state message. Kept pure so it can be unit-tested
- * alongside the sorting pipeline.
- *
- * Why include hideDefaultBranchWorkspace here: without it, a user whose only
- * worktree is the default-branch row and who toggles hide-on would see the
- * "No workspaces found" message with no in-sidebar recovery path.
- */

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -42,6 +42,7 @@ type SectionRowsArgs = {
   importedWorktreesByRepo: Parameters<typeof buildRows>[14]
   newExternalWorktreesInboxByRepo: Parameters<typeof buildRows>[15]
   filterRepoIds: readonly string[]
+  hideDefaultBranchWorkspace: boolean
   visibleWorkspaceHostIds: readonly ExecutionHostId[] | null
   workspaceHostScope: AppState['workspaceHostScope']
 }
@@ -91,9 +92,17 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
         repos: args.visibleReposForRows,
         worktreesByRepo,
         visibleWorktrees: worktrees,
-        filterRepoIds: args.filterRepoIds
+        filterRepoIds: args.filterRepoIds,
+        hideDefaultBranchWorkspace: args.hideDefaultBranchWorkspace
       }),
-    [args.filterRepoIds, args.groupBy, args.visibleReposForRows, worktrees, worktreesByRepo]
+    [
+      args.filterRepoIds,
+      args.groupBy,
+      args.hideDefaultBranchWorkspace,
+      args.visibleReposForRows,
+      worktrees,
+      worktreesByRepo
+    ]
   )
 
   // Why: subscribe on a flat key array (useShallow) so progress ticks don't rebuild the whole row model.

--- a/src/shared/telemetry-events.test.ts
+++ b/src/shared/telemetry-events.test.ts
@@ -524,6 +524,16 @@ describe('add_repo_default_checkout_handoff schema', () => {
     expect(parsed.success).toBe(true)
   })
 
+  it('accepts the hidden-default-checkout reveal reason', () => {
+    const parsed = eventSchemas.add_repo_default_checkout_handoff.safeParse({
+      source: 'clone_url',
+      result: 'revealed_project',
+      reason: 'default_checkout_hidden',
+      nth_repo_added: 2
+    })
+    expect(parsed.success).toBe(true)
+  })
+
   it('rejects raw repo/path context via .strict()', () => {
     const parsed = eventSchemas.add_repo_default_checkout_handoff.safeParse({
       source: 'local_folder_picker',

--- a/src/shared/telemetry-property-schemas.ts
+++ b/src/shared/telemetry-property-schemas.ts
@@ -101,7 +101,8 @@ export const addRepoDefaultCheckoutHandoffReasonSchema = z.enum([
   'show_detected_linked_failed',
   'authoritative_refresh_failed',
   'linked_external_refresh_failed',
-  'refreshed_default_missing'
+  'refreshed_default_missing',
+  'default_checkout_hidden'
 ])
 
 export const setupScriptImportProviderSchema = z.enum(SETUP_SCRIPT_IMPORT_PROVIDERS)

--- a/tests/e2e/add-project-hide-default-branch.spec.ts
+++ b/tests/e2e/add-project-hide-default-branch.spec.ts
@@ -5,8 +5,8 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
-import { mkdtemp } from 'node:fs/promises'
+import { mkdirSync, realpathSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
@@ -35,16 +35,18 @@ async function createMainOnlyRepoFixture(): Promise<string> {
   return repoPath
 }
 
-test.afterEach(() => {
-  for (const root of tempRoots.splice(0)) {
-    rmSync(root, { recursive: true, force: true })
-  }
-})
-
 test.describe('Add project with Hide default branch on', () => {
   test('keeps the filter on and shows the project header without opening the checkout', async ({
-    orcaPage
+    orcaPage,
+    registerPostElectronShutdownCleanup
   }) => {
+    // Why: afterEach runs before the electronApp fixture tears down, so the repo
+    // could still be watched; on Windows that surfaces as EPERM and masks the result.
+    registerPostElectronShutdownCleanup(async () => {
+      for (const root of tempRoots.splice(0)) {
+        await rm(root, { recursive: true, force: true, maxRetries: 5 })
+      }
+    })
     await waitForSessionReady(orcaPage)
     // Why: the dialog locators below assert English copy; pin the UI language so
     // the spec also passes on machines whose OS locale picks another catalog.

--- a/tests/e2e/add-project-hide-default-branch.spec.ts
+++ b/tests/e2e/add-project-hide-default-branch.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Adding a project while "Hide default branch" is on must leave the filter alone
+ * and still land the project in the sidebar as a header — its only row is the
+ * hidden default checkout — instead of silently switching the filter off.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtemp } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+import { worktreeRow } from './worktree-row-locators'
+
+const tempRoots: string[] = []
+
+async function createMainOnlyRepoFixture(): Promise<string> {
+  // Why: realpathSync so the path matches the store's repo.path on macOS, where
+  // os.tmpdir() symlinks to /private/var and the app canonicalizes repo.path.
+  const rootPath = realpathSync(
+    await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-add-project-hidden-default-'))
+  )
+  tempRoots.push(rootPath)
+
+  const repoPath = path.join(rootPath, 'hidden-default-source')
+  mkdirSync(repoPath, { recursive: true })
+  execFileSync('git', ['init'], { cwd: repoPath, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'e2e@test.local'], { cwd: repoPath, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'E2E Test'], { cwd: repoPath, stdio: 'pipe' })
+  writeFileSync(path.join(repoPath, 'README.md'), '# Hidden default source\n')
+  execFileSync('git', ['add', 'README.md'], { cwd: repoPath, stdio: 'pipe' })
+  execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: repoPath, stdio: 'pipe' })
+  execFileSync('git', ['branch', '-M', 'main'], { cwd: repoPath, stdio: 'pipe' })
+  return repoPath
+}
+
+test.afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test.describe('Add project with Hide default branch on', () => {
+  test('keeps the filter on and shows the project header without opening the checkout', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    // Why: the dialog locators below assert English copy; pin the UI language so
+    // the spec also passes on machines whose OS locale picks another catalog.
+    await orcaPage.evaluate(() => window.__store?.getState().updateSettings({ uiLanguage: 'en' }))
+    await expect
+      .poll(() => orcaPage.evaluate(() => window.__store?.getState().settings?.uiLanguage ?? null))
+      .toBe('en')
+    const repoPath = await createMainOnlyRepoFixture()
+
+    // Poll rather than set once: hydration can land after the seed and reset the filters.
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(() => {
+          const state = window.__store?.getState()
+          state?.setSidebarOpen(true)
+          state?.setGroupBy('repo')
+          state?.setShowSleepingWorkspaces(true)
+          state?.setShowActiveOnly(false)
+          state?.setFilterRepoIds([])
+          state?.setHideDefaultBranchWorkspace(true)
+          return {
+            groupBy: state?.groupBy ?? null,
+            hideDefaultBranchWorkspace: state?.hideDefaultBranchWorkspace ?? null
+          }
+        })
+      )
+      .toEqual({ groupBy: 'repo', hideDefaultBranchWorkspace: true })
+
+    await orcaPage.evaluate((folderPath) => {
+      window.__store?.getState().openModal('confirm-add-project-from-folder', { folderPath })
+    }, repoPath)
+    const addProjectDialog = orcaPage.getByRole('dialog', { name: /^Add Project$/i })
+    await expect(addProjectDialog).toBeVisible()
+    await addProjectDialog.getByRole('button', { name: /^Add Project$/ }).click()
+    await expect(addProjectDialog).toBeHidden()
+
+    const readAddedProject = () =>
+      orcaPage.evaluate((mainPath) => {
+        const state = window.__store?.getState()
+        const repo = state?.repos.find((candidate) => candidate.path === mainPath)
+        if (!repo) {
+          return null
+        }
+        const defaultCheckout = (state?.worktreesByRepo[repo.id] ?? []).find(
+          (worktree) => worktree.isMainWorktree
+        )
+        return defaultCheckout ? { repoId: repo.id, defaultCheckoutId: defaultCheckout.id } : null
+      }, repoPath)
+    await expect
+      .poll(readAddedProject, {
+        timeout: 30_000,
+        message: 'added repo default checkout was not loaded'
+      })
+      .not.toBeNull()
+    const added = await readAddedProject()
+    if (!added) {
+      throw new Error('added repo default checkout disappeared after loading')
+    }
+    const { repoId, defaultCheckoutId } = added
+
+    // The project lands as a header; its only row (the default checkout) stays hidden.
+    const projectHeader = orcaPage.locator(`[data-repo-header-id="${repoId}"]`).first()
+    await expect(projectHeader).toBeVisible()
+    await expect(projectHeader).toContainText(path.basename(repoPath))
+    await expect(worktreeRow(orcaPage, defaultCheckoutId)).toHaveCount(0)
+
+    // The filter the user chose is untouched and the hidden checkout was not activated.
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          ({ repoId, defaultCheckoutId }) => {
+            const state = window.__store?.getState()
+            return {
+              activeRepoIsAdded: state?.activeRepoId === repoId,
+              activeWorktreeIsHiddenCheckout: state?.activeWorktreeId === defaultCheckoutId,
+              hideDefaultBranchWorkspace: state?.hideDefaultBranchWorkspace ?? null
+            }
+          },
+          { repoId, defaultCheckoutId }
+        )
+      )
+      .toEqual({
+        activeRepoIsAdded: true,
+        activeWorktreeIsHiddenCheckout: false,
+        hideDefaultBranchWorkspace: true
+      })
+  })
+})


### PR DESCRIPTION
## ELI5

If you tell the sidebar to hide default-branch workspaces, adding a new project used to quietly switch that filter back off and open the new project's `main` at the bottom of the list. Now the filter stays exactly as you set it: the new project shows up as a project header (with its **+** to create a workspace), and its hidden `main` row stays hidden.

## What Changed

- **Placeholder rule** (`empty-project-placeholder-repos.ts`): a repo whose only live rows are default checkouts keeps its header while **Hide default branch** is on, the same way empty projects and filtered Project Group members (#8865) already do. Rows hidden by any *other* filter (Hide sleeping, host scope) do not earn a placeholder, so the #8865 policy for ungrouped projects is unchanged.
- **Add-project handoff** (`project-added-default-checkout.ts`): when the default checkout is hidden by that filter, the handoff no longer flips the filter. It selects the project and issues `revealSidebarRow` for its header, so under Status / PR / None grouping the existing reveal hook switches to project grouping and scrolls there (same path as Cmd+J project selection). Telemetry: `revealed_project` with new reason `default_checkout_hidden`. A folder the user explicitly picked inside the checkout was their real target, so it still opens, with the existing "hidden by sidebar filters" toast.
- **Skip finalizer** (`add-repo-skip-finalization.ts`): never resets the filter. The Hide-sleeping exemption flip is skipped only for imports the filter actually hides (`isDefaultBranchWorkspace`), so a detached-HEAD or provisioned-root main still gets the exemption instead of vanishing.
- Removed the now-dead `setHideDefaultBranchWorkspace` parameter from the handoff and its callers; threaded `hideDefaultBranchWorkspace` into `useSidebarSectionRows`; dropped a stale doc comment whose rationale this change falsified.

## Why

The filter is a row filter, but the handoff treated it as something it had to override to make the new project visible, because an ungrouped project whose only worktree is the default checkout had no sidebar presence under it. Keeping a header for that project (like an empty project) removes the reason to touch the user's setting at all, and unifies grouped vs. ungrouped behavior. Opening the hidden checkout with a toast was considered, but a user who hides default branches did not ask to land on one; the header with its create-workspace button is the natural next step.

## Linked Issue

Fixes #20394

## Visual Proof

Same flow in both: **Hide default branch** on, then add `hidden-default-source` (a repo whose only checkout is `main`) via the folder dialog. Headless Electron build driven over CDP (`tests/e2e/add-project-hide-default-branch.spec.ts` with a screenshot step).

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/jeongph/orca/assets/keep-hide-default-branch/before.png) | ![after](https://raw.githubusercontent.com/jeongph/orca/assets/keep-hide-default-branch/after.png) |

- **Before:** the filter badge is gone (filter switched off), every project's `main` row is back, and the new project's `main` is opened.
- **After:** the filter badge still shows 1 active filter, `hidden-default-source` lands as a header with no rows, the seeded project's `main` stays hidden, and the active workspace is unchanged.

## Testing

Platform: macOS (local host). SSH / runtime hosts are covered by unit tests on the host-qualified handoff (colliding repo IDs across `local` and `runtime:*`), not by a live SSH session.

- [x] I manually tested these changes locally — headless Electron over CDP (screenshots above), plus the new E2E spec.
- [x] Automated tests added/updated:
  - `empty-project-placeholder-repos.test.ts` — default-checkout-only repo keeps its header under the filter; archived rows ignored; no placeholder when a non-default row is hidden by another filter, when a row is visible, outside repo grouping, or for a provisioned-root checkout; repo filter still applies.
  - `add-repo-skip-finalization.test.ts` — filter never reset; sleeping exemption skipped only for filter-hidden imports (branchless main still exempted).
  - `project-added-default-checkout.test.ts` — hidden checkout reveals the header (`revealSidebarRow('repo:…')`, no activation, no filter flip, no exemption flip); explicit subfolder still opens with toast; detached-HEAD and provisioned-root mains still open; colliding host IDs reveal once.
  - `WorktreeList.empty-project-rows.test.ts` — real render: header present, no card, no empty state.
  - `telemetry-events.test.ts` — new reason accepted by the strict schema.
  - `tests/e2e/add-project-hide-default-branch.spec.ts` — end-to-end: filter stays on, header renders, checkout row hidden and not activated.
- `pnpm typecheck`, the changed-file code-quality gate, and the sidebar / telemetry / cmd-j suites (319 files, 2775 tests) pass locally.

## AI Disclosure

Written with Claude Code (Claude Fable 5.1); reviewed with opus-model review agents (code, test coverage, comment accuracy). Their two real findings — the finalizer guard dropping detached-HEAD mains, and no landing spot outside project grouping — are fixed and covered by the tests above. All code was read and verified by me.

## Review

- **Cross-platform:** renderer-only; no paths, shortcuts, or process handling touched.
- **SSH / remote / local:** the handoff keeps its `executionHostId` filtering; the hidden-checkout branch runs after host-qualified default-checkout selection, and the colliding-ID test proves one reveal per add. The placeholder reads `worktreesByRepo` across hosts, same as the existing zero-worktree rule.
- **Folder workspaces:** not in the worktree filter pipeline; `isDefaultBranchWorkspace` is false for branchless rows, so they keep the old activation path.
- **Agents / integrations / git providers:** not involved.
- **Performance:** the placeholder check is one extra pass over `repos` inside an existing `useMemo`, keyed on the new flag.
- **UI:** no new components or copy; the header and toast are existing surfaces. Users who keep the filter on now see headers for default-checkout-only projects instead of the "No workspaces found / Clear Filters" empty state (Clear Filters stays in the filter menu).
- **Security:** none; no new IPC, storage, or network paths. The telemetry reason is an enum value under the existing `.strict()` schema.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Revealing the header outside project grouping switches the sidebar to project grouping; that is the existing `useSidebarRevealRequests` behavior for project targets, not new logic.
- Mobile has its own workspace list and no empty-project headers; untouched.
- Backwards compatibility: `add_repo_default_checkout_handoff` gains one enum reason; no wire or persisted-state changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with Claude Code
