### PR TITLE
fix(sidebar): show agent activity before workspace activation

### DIFF
--- a/src/renderer/src/components/terminal-parked-watcher-sync-entries.test.tsx
+++ b/src/renderer/src/components/terminal-parked-watcher-sync-entries.test.tsx
@@ -8,7 +8,8 @@ import type { TerminalColdActivationController } from './terminal-cold-activatio
 
 const mocks = vi.hoisted(() => ({
   sync: vi.fn(),
-  prune: vi.fn()
+  prune: vi.fn(),
+  canCover: vi.fn(() => true)
 }))
 vi.mock('@/store', () => ({
   useAppStore: Object.assign(() => 'unverifiable', {
@@ -19,7 +20,7 @@ vi.mock('@/lib/workspace-terminal-host-authority', () => ({
   createWorkspaceTerminalHostAuthoritySelector: () => () => 'unverifiable'
 }))
 vi.mock('./terminal-pane/terminal-parked-tab-watchers', () => ({
-  canWatcherCoverParkedTerminalTab: () => true,
+  canWatcherCoverParkedTerminalTab: mocks.canCover,
   disposeAllParkedTerminalWatchers: vi.fn(),
   pruneParkedTerminalWatchers: mocks.prune,
   syncParkedTerminalTabWatchersForWorkspaces: mocks.sync,
@@ -32,45 +33,52 @@ const PARKED_WORKTREE_ID = 'repo-1::/worktree-0'
 const surfaceIds = Array.from({ length: SURFACE_COUNT }, (_, index) => `repo-1::/worktree-${index}`)
 
 let root: Root | undefined
+let rerenderWatcher: () => Promise<void>
 afterEach(async () => {
   await act(async () => root?.unmount())
   vi.clearAllMocks()
+  mocks.canCover.mockReturnValue(true)
 })
 
-function renderWatcherEffects(): Promise<void> {
+function renderWatcherEffects(
+  overrides: Partial<TerminalColdActivationController> = {}
+): Promise<void> {
+  const controller = {
+    activationDeferredMountTabIdsByWorktreeRef: { current: new Map() },
+    activeTabId: null,
+    activeTabIdByWorktree: {},
+    activeView: 'terminal',
+    activeWorktreeId: null,
+    activityTerminalPortals: [],
+    anyMountedWorktreeHasLayout: false,
+    backgroundMountRevision: 0,
+    effectiveParkedTerminalWorktreeIds: new Set([PARKED_WORKTREE_ID]),
+    evictionExemptTerminalTabIds: new Set(['tab-exempt']),
+    getEffectiveLayoutForWorktree: () => null,
+    groupsByWorktree: {},
+    hydrationSucceeded: false,
+    measurableBackgroundWorktreeIdsRef: { current: new Set() },
+    mountedWorktreeIdsRef: { current: new Set([PARKED_WORKTREE_ID]) },
+    pendingStartupByTabId: {},
+    // Another workspace is on screen, so the mounted one is hidden and parks.
+    renderedActiveWorktreeId: 'repo-1::/worktree-9',
+    tabsByWorktree: {
+      [PARKED_WORKTREE_ID]: [{ id: 'tab-parked' }, { id: 'tab-exempt' }]
+    },
+    terminalParkingEnabled: true,
+    terminalStartupRestorationReady: false,
+    terminalTitleSnapshotAuthorityEnabled: true,
+    workspaceSessionReady: false,
+    workspaceSurfaceIds: surfaceIds,
+    ...overrides
+  } as unknown as TerminalColdActivationController
   function Watcher(): null {
-    useTerminalWatcherEffects({
-      activationDeferredMountTabIdsByWorktreeRef: { current: new Map() },
-      activeTabId: null,
-      activeTabIdByWorktree: {},
-      activeView: 'terminal',
-      activeWorktreeId: null,
-      activityTerminalPortals: [],
-      anyMountedWorktreeHasLayout: false,
-      backgroundMountRevision: 0,
-      effectiveParkedTerminalWorktreeIds: new Set([PARKED_WORKTREE_ID]),
-      evictionExemptTerminalTabIds: new Set(['tab-exempt']),
-      getEffectiveLayoutForWorktree: () => null,
-      groupsByWorktree: {},
-      hydrationSucceeded: false,
-      measurableBackgroundWorktreeIdsRef: { current: new Set() },
-      mountedWorktreeIdsRef: { current: new Set([PARKED_WORKTREE_ID]) },
-      pendingStartupByTabId: {},
-      // Another workspace is on screen, so the mounted one is hidden and parks.
-      renderedActiveWorktreeId: 'repo-1::/worktree-9',
-      tabsByWorktree: {
-        [PARKED_WORKTREE_ID]: [{ id: 'tab-parked' }, { id: 'tab-exempt' }]
-      },
-      terminalParkingEnabled: true,
-      terminalStartupRestorationReady: false,
-      terminalTitleSnapshotAuthorityEnabled: true,
-      workspaceSessionReady: false,
-      workspaceSurfaceIds: surfaceIds
-    } as unknown as TerminalColdActivationController)
+    useTerminalWatcherEffects({ ...controller, ...overrides })
     return null
   }
   root = createRoot(document.createElement('div'))
-  return act(async () => root?.render(<Watcher />))
+  rerenderWatcher = () => act(async () => root?.render(<Watcher />))
+  return rerenderWatcher()
 }
 
 function lastSyncEntries(): Map<string, ParkedTerminalTabWatcherSyncEntry> {
@@ -106,5 +114,57 @@ describe('parked terminal watcher sync entries', () => {
     // Pre-fix this was one empty Set per surface (422 of them) on every fire.
     expect(unmountedSets.size).toBe(1)
     expect([...unmountedSets][0]?.size).toBe(0)
+  })
+  it.each(['repo-1::/never-visited', 'folder:never-visited'])(
+    'watches a live terminal in never-activated workspace %s and restores its title',
+    async (workspaceId) => {
+      const tab = { id: 'background-agent', ptyId: 'live-pty' }
+      await renderWatcherEffects({
+        anyMountedWorktreeHasLayout: true,
+        workspaceSurfaceIds: [...surfaceIds, workspaceId],
+        tabsByWorktree: { [workspaceId]: [tab] }
+      } as unknown as Partial<TerminalColdActivationController>)
+
+      const entry = lastSyncEntries().get(workspaceId)
+      expect([...entry!.parkedTabIds]).toEqual([tab.id])
+      expect([...entry!.restoreTitleOnStartTabIds!]).toEqual([tab.id])
+      expect(mocks.canCover).toHaveBeenCalledWith(workspaceId, tab)
+      expect(lastSyncEntries().get(surfaceIds[1])!.parkedTabIds.size).toBe(0)
+    }
+  )
+
+  it('does not watch a never-activated tab whose host cannot provide coverage', async () => {
+    mocks.canCover.mockReturnValue(false)
+    await renderWatcherEffects({
+      tabsByWorktree: { [surfaceIds[1]]: [{ id: 'unverifiable-tab' }] }
+    } as unknown as Partial<TerminalColdActivationController>)
+
+    const entry = lastSyncEntries().get(surfaceIds[1])!
+    expect(entry.parkedTabIds.size).toBe(0)
+    expect(entry.restoreTitleOnStartTabIds).toBeUndefined()
+  })
+  it('starts watching when host snapshot capability resolves after tab admission', async () => {
+    const overrides = {
+      terminalProviderSnapshotCapabilityRevision: 0,
+      tabsByWorktree: { [surfaceIds[1]]: [{ id: 'background-agent', ptyId: 'live-pty' }] }
+    } as unknown as Partial<TerminalColdActivationController>
+    mocks.canCover.mockReturnValue(false)
+    await renderWatcherEffects(overrides)
+    expect(lastSyncEntries().get(surfaceIds[1])!.parkedTabIds.size).toBe(0)
+
+    mocks.canCover.mockReturnValue(true)
+    overrides.terminalProviderSnapshotCapabilityRevision = 1
+    await rerenderWatcher()
+
+    expect([...lastSyncEntries().get(surfaceIds[1])!.parkedTabIds]).toEqual(['background-agent'])
+  })
+
+  it('leaves activity-portal terminals with their existing consumer', async () => {
+    await renderWatcherEffects({
+      tabsByWorktree: { [surfaceIds[1]]: [{ id: 'portal-agent', ptyId: 'live-pty' }] },
+      activityTerminalPortals: [{ worktreeId: surfaceIds[1], tabId: 'portal-agent' }]
+    } as unknown as Partial<TerminalColdActivationController>)
+
+    expect(lastSyncEntries().get(surfaceIds[1])!.parkedTabIds.size).toBe(0)
   })
 })

--- a/src/renderer/src/components/use-terminal-watcher-effects.ts
+++ b/src/renderer/src/components/use-terminal-watcher-effects.ts
@@ -17,8 +17,7 @@ import { getStructuredAgentLaunchStatus } from '@/lib/structured-agent-session-l
 import { AGENT_SESSION_PROVIDER_HANDLE_PROVIDERS } from '../../../shared/agent-session-provider-handle'
 import type { TerminalColdActivationController } from './terminal-cold-activation'
 
-// Why shared: only a mounted workspace can park a tab, and the watcher sync only reads
-// this set, so every other surface would otherwise allocate its own empty one per fire.
+// Why shared: surfaces without watchable live tabs need no per-pass allocation.
 const NO_PARKED_TAB_IDS: ReadonlySet<string> = new Set()
 
 export function useTerminalWatcherEffects(controller: TerminalColdActivationController): void {
@@ -44,6 +43,7 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
     renderedActiveWorktreeId,
     tabsByWorktree,
     terminalParkingEnabled,
+    terminalProviderSnapshotCapabilityRevision,
     terminalStartupRestorationReady,
     terminalTitleSnapshotAuthorityEnabled,
     workspaceSessionReady,
@@ -100,6 +100,23 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
           }
         }
       }
+      if (tabs.length > 0 && !mountedWorktreeIdsRef.current.has(workspaceId)) {
+        const backgroundTabIds = tabs
+          .filter(
+            (tab) =>
+              canWatcherCoverParkedTerminalTab(workspaceId, tab) &&
+              !findActivityTerminalPortal(activityTerminalPortals, {
+                worktreeId: workspaceId,
+                tabId: tab.id
+              })
+          )
+          .map((tab) => tab.id)
+        if (backgroundTabIds.length > 0) {
+          // CLI-created live terminals have never mounted a pane to consume host title facts.
+          parkedTabIds = new Set(backgroundTabIds)
+          deferredTabIds = parkedTabIds
+        }
+      }
       syncEntriesByWorktreeId.set(workspaceId, {
         tabs,
         parkedTabIds,
@@ -123,6 +140,7 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
     renderedActiveWorktreeId,
     tabsByWorktree,
     terminalParkingEnabled,
+    terminalProviderSnapshotCapabilityRevision,
     terminalTitleSnapshotAuthorityEnabled,
     workspaceSessionReady,
     workspaceSurfaceIds


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​167 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​36 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |

<!-- /orca-pr-loc -->

## ELI5

An agent started with `orca worktree create --agent` could be working while its sidebar card showed no agent activity until clicked. Its activity now appears while the workspace stays in the background.

## What Changed

Reuse parked-terminal watchers for eligible live tabs in never-mounted workspaces. Request the initial title snapshot to recover events emitted before registration, and retry admission when local snapshot capability, paired-host capability, or the SSH parking setting changes. Preserve activity-portal ownership and existing watcher cleanup.

## Why

The reproduction already had hydrated tabs, PTY bindings, and stable-leaf layouts. The missing input was the live title: neither a mounted pane nor a parked watcher consumed host facts before the first activation. This fixes that missing consumer without introducing a new status store or precedence rule.

The existing pass still scans workspace surfaces; additional coverage costs one watcher and initial snapshot per eligible live PTY, not per saved workspace. Default fact-mode watchers share the existing channel and add no xterm mounts, raw-byte subscriptions, or polling. Legacy byte-parser mode retains its per-PTY output-processing cost. The 423-surface allocation test remains covered.

## Linked Issue

Related to #18704 (similar click-to-reveal symptom). This PR proves the local CLI-created Codex/title-consumer case; it does not claim to close that issue's paired OMP attribution case.

## Visual Proof

Captured through Playwright CDP in a separate hidden Electron instance. The existing user app was not restarted or stopped.

Before: a real Codex process was running in `status-repro`, with no selected workspace. The card showed generic Active but no working glyph or agent row. Clicking made the row appear.

![Before: never-activated agent workspace](https://github.com/user-attachments/assets/8891ba11-8f49-41a9-b55d-4e6d31275678)

After: freshly CLI-created `status-fixed-fresh` shows working activity while `status-repro` remains selected. The new-card setting was enabled for this capture; the change does not alter card styling. Completion and watcher-to-mounted-pane handoff were also checked.

![After: background agent activity before activation](https://github.com/user-attachments/assets/be07c63c-51d8-42e0-bed4-b51663a9ccc5)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

All app/test runs used `ORCA_BACKGROUND_LAUNCH=1`.

- `pnpm tc`: passed, including final rerun.
- Configured sidebar plus watcher/fact suites: **307 files, 2,633 tests passed** with `pnpm exec vitest run --config config/vitest.config.ts ...`.
- Final focused regression suite: **10 passed**, including git/folder workspace admission, delayed local/paired host capability, SSH parking changes, portal ownership, and empty-surface allocation.
- Mutation: disabling never-mounted admission fails both git/folder cases; removing the capability dependency fails the delayed-admission case. Removing the paired-capability and SSH-setting dependencies also fails both new regression cases. Restored code passes.
- `pnpm run check:code-quality:changed`: zero new findings.
- `pnpm run check:react-doctor:changed`: zero issues; score unavailable.
- `git diff --check`: passed.

The brief's literal `pnpm exec vitest run src/renderer/src/components/sidebar` failed without the repository config (210 files failed, 91 passed; aliases/environment setup missing). The configured run above passed.

## Review

A second Astra medium review of the final diff found no concrete issues. The CI casting-rule failure is addressed with fully typed fixtures and a hook input type restricted to its consumed controller fields; no runtime behavior changed. Local typecheck, all 10 focused tests, changed-code quality, React Doctor, and the newer casting rule passed.

Astra medium review found one remote-admission dependency gap, repaired by adding two existing controller values to the effect dependencies. No additional abstractions were needed. Follow-up validation passed typechecking, 301 sidebar files / 2,537 tests, all 10 focused tests, and both changed-code gates. Self-reviewed consumer ownership, snapshot catch-up, cleanup, and allocation scope. Live validation covered macOS Codex working, normal completion, first activation, and terminal close. Folder coverage is automated. Live SSH/WSL/Linux/Windows, mixed-version paired clients, explicit blocked/waiting/interrupted hook states, and large-profile CPU/heap measurements remain unverified. Existing remote capability and exit-verdict gates are reused; no wire shape changes.

## Agent skill upstream boundary

- [x] Not applicable: no agent-skill source or fixtures changed.

## Notes

**Regression attribution correction:** the reporter says this began 1–5 days ago. #11445 is historical background-path context, not an established cause of that recent onset. No regressing PR is identified.

A historical check now reproduces the same missing-row/first-click repair on September 6 commit `bf4e2705046cf9ef9c915929a9646da85717af07`, before the reported window and before the September 10–11 mounting/status-store changes. Built and launched that checkpoint in the same worktree with a fresh isolated profile and `ORCA_BACKGROUND_LAUNCH=1`; created an inert real Codex agent via the CLI. Before activation, tabs/PTY bindings existed, runtime-title and hook-status maps were empty, and connected Codex PID 36123 had a working title. Clicking populated the title and rendered the agent row. Returned to the unchanged PR branch afterward.

This proves the consumer gap existed in that older source under **today's Codex v0.154.0 and installed dependencies**. It does not reproduce the reporter's previous full environment or explain what changed for them recently. The fix addresses the demonstrated gap; attribution of the recent onset remains open.

<details>
<summary>September 6 checkpoint: before activation and after first click</summary>

![September 6 source: missing agent row before activation](https://github.com/user-attachments/assets/5de55303-2e0c-461e-afb8-2d090530e70b)

![Same checkpoint: agent row appears after first click](https://github.com/user-attachments/assets/91b449ff-92cb-47f2-afab-ba5d7b04ff56)

</details>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full lint/build and remaining CI checks will be covered by CI; local focused tests, typecheck, and changed-code gates passed as detailed above


