### PR TITLE
fix(remote): isolate client focus and notifications by run origin

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3320,8 +3320,8 @@
       "coveredProviders": ["local", "orca-server"],
       "coverageNotes": "A real two-client integration harness pairs two authenticated devices to one OrcaRuntimeService over WebSockets with E2EE and drives worktree.create through the real RPC dispatcher, in both headed-notifier and headless orca-serve shapes. The headless case is a modeled `orca serve` runtime shape — no notifier, no attached window — not a CLI bootstrap, and the in-process reveal non-regression calls createManagedWorktree directly. A headed Electron journey runs the desktop app as the remote server with two independently paired web clients in separate partitions and asserts each client's rendered active worktree. Windows and Linux are covered by the platform-neutral contract only; the reported field topology was a Windows server with mixed-OS clients.",
       "motivatingLinks": ["https://github.com/stablyai/orca/issues/11027"],
-      "invariant": "View intent belongs to the connection that requested it. With no explicit navigation target, a workspace create arriving over a paired desktop/web client connection activates only that caller; it must not emit an activateWorktree client event to sibling connections or drive the host renderer. An explicit navigation of host/clients/all remains an allowed, tested follow intent. Shared model state — repo/worktree catalogs, terminals, agent output — must keep propagating to every client unchanged. In-process and CLI creates keep notifying the host and all clients so a headless server's only viewer still gets its reveal.",
-      "oracle": "notifyActivateWorktree takes its navigation target as a required parameter, so a create call site that forgets to forward it is a compile error rather than a silent fallback to broadcasting — mutation testing confirmed all six call sites (folder, git, and remote/SSH branches, startup and no-startup each) are killed by typecheck. Behaviorally: two paired clients subscribe to runtime.clientEvents. Client A creates a workspace with activate:true; a reposChanged fence emitted after the create must be the next frame each client sees, proving no activation frame was interleaved, while worktreesChanged still arrives on both streams. The host notifier's activateWorktree is asserted not called and the host's mirrored selection is unchanged. Repeated ordinary worktree.activate calls by A are the negative control. The same file asserts the in-process create still reaches host and clients, headed and headless. The Electron journey asserts the observer's data-rendered-active-worktree-id is unchanged while the created workspace still appears in its sidebar.",
+      "invariant": "Each viewer owns navigation. Paired UI requests never steer other viewers, including explicit legacy host/clients/all targets. CLI activation inherits its launching run's device; unknown origin stays background. Host-origin creates reveal only on the host. New clients reject unaddressed activation and ambient follow snapshots from old hosts.",
+      "oracle": "Two authenticated WebSocket clients subscribe to client events. Current and legacy CLI payloads inherit A's terminal origin; A receives addressed activation while B receives shared catalog updates and a reposChanged fence with no activation. The host selection is unchanged. Tests cover headed-notifier and headless service shapes, reconnect with no replay, caller selection, host-only activation, and crossed runtime identities.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/multi-client-navigation-isolation.integration.test.ts src/main/runtime/rpc/methods/worktree-create-navigation.test.ts",
         "pnpm run test:e2e:multi-client-navigation -- tests/e2e/multi-client-navigation-isolation.spec.ts"
@@ -3336,10 +3336,10 @@
           "file": "src/main/runtime/multi-client-navigation-isolation.integration.test.ts",
           "assertions": [
             "keeps a paired client workspace create-with-activate off every other client and the host",
-            "still reveals to every client when a paired caller asks for all-surface navigation",
+            "isolates current and legacy CLI activation (headless=%s)",
             "does not replay a missed create activation to a reconnecting observer",
             "keeps create activation caller-scoped on a headless orca serve host",
-            "still reveals a host-originated create-with-activate on the host and every client",
+            "reveals a host-originated create only on the host",
             "keeps worktree navigation local to each paired runtime client by default",
             "routes explicit host and paired-client follow intent without changing the default"
           ]
@@ -3349,8 +3349,8 @@
           "assertions": [
             "resolves create activation from the paired runtime client kind",
             "resolves create activation from the paired mobile client kind",
-            "honors an explicit follow navigation on create",
-            "keeps an explicit all-surface reveal from a paired caller"
+            "keeps explicit follow navigation local to its caller",
+            "keeps explicit all-surface navigation local to its caller"
           ]
         },
         {

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -154,6 +154,18 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       !client.isRemote && shouldUseRendererBackedInteractiveTerminal(command)
     const focus = flags.get('focus') === true
     const result = await client.call<{ terminal: RuntimeTerminalCreate }>('terminal.create', {
+      ...(process.env.ORCA_WORK_ORIGIN_SESSION_ID && process.env.ORCA_AGENT_SESSION_SPAWN_TOKEN
+        ? {
+            callerOriginSession: {
+              sessionId: process.env.ORCA_WORK_ORIGIN_SESSION_ID,
+              spawnToken: process.env.ORCA_AGENT_SESSION_SPAWN_TOKEN
+            }
+          }
+        : {}),
+      cliProvenanceRequest: {},
+      ...(process.env.ORCA_TERMINAL_HANDLE
+        ? { callerTerminalHandle: process.env.ORCA_TERMINAL_HANDLE }
+        : {}),
       worktree: await getBrowserWorktreeSelector(flags, cwd, client),
       command,
       title: getOptionalStringFlag(flags, 'title'),
@@ -179,6 +191,16 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       throw new RuntimeClientError('invalid_argument', '--direction must be horizontal or vertical')
     }
     const result = await client.call<{ split: RuntimeTerminalSplit }>('terminal.split', {
+      ...(process.env.ORCA_WORK_ORIGIN_SESSION_ID && process.env.ORCA_AGENT_SESSION_SPAWN_TOKEN
+        ? {
+            callerOriginSession: {
+              sessionId: process.env.ORCA_WORK_ORIGIN_SESSION_ID,
+              spawnToken: process.env.ORCA_AGENT_SESSION_SPAWN_TOKEN
+            }
+          }
+        : {}),
+      callerTerminalHandle: process.env.ORCA_TERMINAL_HANDLE,
+      cliProvenanceRequest: {},
       terminal: await getTerminalHandle(flags, cwd, client),
       direction: directionFlag,
       command: getOptionalStringFlag(flags, 'command')

--- a/src/cli/handlers/worktree-result-warnings.ts
+++ b/src/cli/handlers/worktree-result-warnings.ts
@@ -1,0 +1,23 @@
+type HookWarningResult = {
+  warning?: string
+}
+
+type PreservedBranchResult = {
+  preservedBranch?: {
+    branchName: string
+  }
+}
+
+export function printHookWarning(result: HookWarningResult, json: boolean): void {
+  if (!json && result.warning) {
+    console.error(`warning: ${result.warning}`)
+  }
+}
+
+export function printPreservedBranchWarning(result: PreservedBranchResult, json: boolean): void {
+  if (!json && result.preservedBranch) {
+    console.error(
+      `warning: local branch "${result.preservedBranch.branchName}" was kept because Git could not safely delete it`
+    )
+  }
+}

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -1,3 +1,4 @@
+import { printHookWarning, printPreservedBranchWarning } from './worktree-result-warnings'
 import type {
   RuntimeWorktreeListResult,
   RuntimeWorktreePsResult,
@@ -37,30 +38,6 @@ import {
   resolveCreateParentSelector
 } from './worktree-create-parent-selector'
 import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
-
-type HookWarningResult = {
-  warning?: string
-}
-
-type PreservedBranchResult = {
-  preservedBranch?: {
-    branchName: string
-  }
-}
-
-function printHookWarning(result: HookWarningResult, json: boolean): void {
-  if (!json && result.warning) {
-    console.error(`warning: ${result.warning}`)
-  }
-}
-
-function printPreservedBranchWarning(result: PreservedBranchResult, json: boolean): void {
-  if (!json && result.preservedBranch) {
-    console.error(
-      `warning: local branch "${result.preservedBranch.branchName}" was kept because Git could not safely delete it`
-    )
-  }
-}
 
 function assertParentWorktreeFlagsCompatible(flags: Map<string, string | boolean>): void {
   if (flags.has('parent-worktree') && flags.get('no-parent') === true) {
@@ -239,7 +216,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       }
     }
     const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')
-    const activate = flags.get('activate') === true || flags.get('run-hooks') === true
+    const activate = flags.get('activate') === true
     const name = getRequiredStringFlag(flags, 'name')
     const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', {
       repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
@@ -264,6 +241,14 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       callerTerminalHandle,
       // Why: marks the workspace as CLI-created so the sidebar can badge and
       // filter it. Sent on every `worktree create` — hand-typed or agent-run.
+      ...(process.env.ORCA_WORK_ORIGIN_SESSION_ID && process.env.ORCA_AGENT_SESSION_SPAWN_TOKEN
+        ? {
+            callerOriginSession: {
+              sessionId: process.env.ORCA_WORK_ORIGIN_SESSION_ID,
+              spawnToken: process.env.ORCA_AGENT_SESSION_SPAWN_TOKEN
+            }
+          }
+        : {}),
       cliProvenanceRequest: callerTerminalHandle ? { callerTerminalHandle } : {},
       ...(startupAgent
         ? {

--- a/src/main/daemon/daemon-create-or-attach-result.ts
+++ b/src/main/daemon/daemon-create-or-attach-result.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { ShellReadyState, TerminalSnapshot } from './types'
 import type { AgentSessionClaimedSpawnResult } from '../../shared/agent-session-host-authority'
@@ -10,6 +11,7 @@ export type DaemonCreateOrAttachResult = {
   shellState: ShellReadyState
   historySeeded?: boolean
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   /** Undefined only when talking to a daemon predating WSL session context. */
   wslDistro?: string | null
   agentSessionEnsure?: AgentSessionClaimedSpawnResult
@@ -23,15 +25,18 @@ export type DaemonCreateOrAttachResult = {
 }
 
 export function getDaemonSessionResultMetadata(session: {
+  workOrigin?: WorkOrigin
   launchAgent: TuiAgent | null
   historySeeded: boolean | undefined
   wslDistro: string | null
 }): {
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   historySeeded?: boolean
   wslDistro: string | null
 } {
   return {
+    ...(session.workOrigin !== undefined ? { workOrigin: session.workOrigin } : {}),
     ...(session.launchAgent ? { launchAgent: session.launchAgent } : {}),
     ...(session.historySeeded !== undefined ? { historySeeded: session.historySeeded } : {}),
     // Why: null authoritatively identifies a native session; omission is

--- a/src/main/daemon/daemon-pty-spawn-request.ts
+++ b/src/main/daemon/daemon-pty-spawn-request.ts
@@ -116,6 +116,9 @@ export abstract class DaemonPtySpawnRequest extends DaemonPtyRuntimeState {
         command: context.attachOnly ? undefined : opts.command,
         startupCommandDelivery: context.attachOnly ? undefined : opts.startupCommandDelivery,
         launchAgent: context.attachOnly ? undefined : opts.launchAgent,
+        ...(context.attachOnly || opts.workOrigin === undefined
+          ? {}
+          : { workOrigin: opts.workOrigin }),
         ...(context.attachOnly && !context.emulateLegacyAttachOnly ? { attachOnly: true } : {}),
         shellOverride: context.attachOnly ? undefined : opts.shellOverride,
         terminalWindowsWslDistro: context.attachOnly ? undefined : opts.terminalWindowsWslDistro,

--- a/src/main/daemon/daemon-pty-spawn-result.ts
+++ b/src/main/daemon/daemon-pty-spawn-result.ts
@@ -91,8 +91,10 @@ export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
     } else if (providerWslDistro === null || result.isNew) {
       this.wslDistrosBySessionId.delete(sessionId)
     }
-    const launchIdentity = (): { launchAgent?: NonNullable<typeof result.launchAgent> } =>
-      result.launchAgent ? { launchAgent: result.launchAgent } : {}
+    const launchIdentity = () => ({
+      ...(result.launchAgent ? { launchAgent: result.launchAgent } : {}),
+      ...(result.workOrigin !== undefined ? { workOrigin: result.workOrigin } : {})
+    })
 
     if (effectiveCwd) {
       this.initialCwds.set(sessionId, effectiveCwd)
@@ -288,7 +290,6 @@ export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
     const isAltScreen = reattachSnapshot.modes.alternateScreen
     const snapshotPrefix = reattachSnapshot.scrollbackAnsi + reattachSnapshot.rehydrateSequences
     const snapshotFrame = reattachSnapshot.snapshotAnsi
-    const snapshotPayload = snapshotPrefix + snapshotFrame
     // Why kitty flags ride beside the payload, not inside it: the snapshot reaches renderer xterms where POST_REPLAY_REATTACH_RESET's kitty reset must win (terminal-query-authority.md §kitty).
     // Why known `0` is no longer dropped: the pane tracker must be able to tell
     // "the app negotiated nothing" from "this reattach proved nothing".
@@ -302,7 +303,7 @@ export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
       ...claimResult(),
       ...launchIdentity(),
       ...(providerWslDistro !== undefined ? { wslDistro: providerWslDistro } : {}),
-      snapshot: snapshotPayload,
+      snapshot: snapshotPrefix + snapshotFrame,
       snapshotCols: reattachSnapshot.cols,
       snapshotRows: reattachSnapshot.rows,
       // Why only for an alt frame: normal history remains safe to replay at its capture grid.

--- a/src/main/daemon/daemon-terminal-admission.ts
+++ b/src/main/daemon/daemon-terminal-admission.ts
@@ -1,3 +1,4 @@
+import { normalizeWorkOrigin } from '../../shared/work-origin'
 import { performance } from 'node:perf_hooks'
 import type { BackgroundTransientFactRelay } from './daemon-background-transient-facts'
 import type { DaemonClientConnections } from './daemon-client-connections'
@@ -103,6 +104,9 @@ export class DaemonTerminalAdmission {
         command: payload.command,
         startupCommandDelivery: payload.startupCommandDelivery,
         ...(attachOnly ? { attachOnly: true } : {}),
+        ...(payload.workOrigin !== undefined
+          ? { workOrigin: normalizeWorkOrigin(payload.workOrigin) }
+          : {}),
         ...(isTuiAgent(payload.launchAgent) ? { launchAgent: payload.launchAgent } : {}),
         shellOverride: payload.shellOverride,
         terminalWindowsWslDistro: payload.terminalWindowsWslDistro,
@@ -158,6 +162,7 @@ export class DaemonTerminalAdmission {
       pid: result.pid,
       shellState: result.shellState,
       incarnationId: result.incarnationId,
+      ...(result.workOrigin !== undefined ? { workOrigin: result.workOrigin } : {}),
       ...(result.launchAgent ? { launchAgent: result.launchAgent } : {}),
       wslDistro: result.wslDistro,
       ...(result.historySeeded !== undefined ? { historySeeded: result.historySeeded } : {}),

--- a/src/main/daemon/session-options.ts
+++ b/src/main/daemon/session-options.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { SubprocessHandle } from './session-subprocess-handle'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { PtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
@@ -9,6 +10,7 @@ export type SessionOptions = {
   rows: number
   terminalHandle?: string
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   subprocess: SubprocessHandle
   shellReadySupported: boolean
   shellReadyTimeoutMs?: number

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -15,21 +15,17 @@ import type { TuiAgent } from '../../shared/tui-agent'
 import { randomUUID } from 'node:crypto'
 import { PtyStartupIngress } from '../../shared/pty-startup-ingress'
 
-import type {
-  SessionState,
-  ShellReadyState,
-  TakePendingOutputResult,
-  TerminalSnapshot
-} from './types'
+import type * as SessionTypes from './types'
 import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 export class Session {
   readonly sessionId: string
   readonly incarnationId = randomUUID()
   readonly terminalHandle: string | null
+  readonly workOrigin: SessionOptions['workOrigin']
   readonly launchAgent: TuiAgent | null
   readonly wslDistro: string | null
-  private _state: SessionState = 'running'
+  private _state: SessionTypes.SessionState = 'running'
   private _exitCode: number | null = null
   private _disposed = false
   private subprocess: SubprocessHandle
@@ -44,6 +40,7 @@ export class Session {
   constructor(opts: SessionOptions) {
     this.sessionId = opts.sessionId
     this.terminalHandle = opts.terminalHandle ?? null
+    this.workOrigin = opts.workOrigin
     this.launchAgent = opts.launchAgent ?? null
     this.wslDistro = opts.wslDistro ?? null
     this.subprocess = opts.subprocess
@@ -95,11 +92,11 @@ export class Session {
     this.subprocess.onExit((code, cause) => this.handleSubprocessExit(code, cause))
   }
 
-  get state(): SessionState {
+  get state(): SessionTypes.SessionState {
     return this._state
   }
 
-  get shellState(): ShellReadyState {
+  get shellState(): SessionTypes.ShellReadyState {
     return this.shellReady.state
   }
 
@@ -221,7 +218,7 @@ export class Session {
     this.producerPause.release({ resume: true })
   }
 
-  getSnapshot(opts: { scrollbackRows?: number } = {}): TerminalSnapshot | null {
+  getSnapshot(opts: { scrollbackRows?: number } = {}): SessionTypes.TerminalSnapshot | null {
     this.startupIngress.snapshotBarrier()
     return this.output.getSnapshot(opts)
   }
@@ -237,7 +234,7 @@ export class Session {
   takePendingOutput(
     includeSnapshot: boolean,
     opts: { teardownSnapshot?: boolean } = {}
-  ): TakePendingOutputResult | null {
+  ): SessionTypes.TakePendingOutputResult | null {
     if (this._disposed) {
       return null
     }

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { ShellReadyState, TerminalSnapshot } from './types'
@@ -20,6 +21,7 @@ export type CreateOrAttachOptions = {
   command?: string
   startupCommandDelivery?: StartupCommandDelivery
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   /** Missing ownership is not permission to create during stable-pane adoption. */
   attachOnly?: boolean
   /** Explicit shell the renderer asked for, forwarded to the subprocess. */
@@ -50,6 +52,7 @@ export type CreateOrAttachResult = {
   shellState: ShellReadyState
   historySeeded?: boolean
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   wslDistro: string | null
   attachToken: symbol
   incarnationId: PtyIncarnationId

--- a/src/main/daemon/terminal-host-options.ts
+++ b/src/main/daemon/terminal-host-options.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { SubprocessHandle } from './session-subprocess-handle'
@@ -14,6 +15,7 @@ export type TerminalHostOptions = {
     command?: string
     startupCommandDelivery?: StartupCommandDelivery
     launchAgent?: TuiAgent
+    workOrigin?: WorkOrigin
     shellOverride?: string
     terminalWindowsWslDistro?: string | null
     terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -139,6 +139,7 @@ async function spawnAndPublishSession(
     rows: size.rows,
     terminalHandle: opts.env?.ORCA_TERMINAL_HANDLE,
     launchAgent: opts.launchAgent,
+    workOrigin: opts.workOrigin,
     subprocess,
     ownerBackend: resolvePtyOwnerBackend({
       platform: process.platform,

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -1,9 +1,5 @@
-import type {
-  ConfirmForegroundProcessRequest,
-  ConfirmShellForegroundRequest,
-  GetForegroundProcessRequest,
-  InspectProcessRequest
-} from './daemon-foreground-process-protocol'
+import type { WorkOrigin } from '../../shared/work-origin'
+import type * as ForegroundProcessProtocol from './daemon-foreground-process-protocol'
 
 export type {
   ConfirmForegroundProcessRequest,
@@ -71,6 +67,7 @@ export type CreateOrAttachRequest = {
     command?: string
     startupCommandDelivery?: StartupCommandDelivery
     launchAgent?: TuiAgent
+    workOrigin?: WorkOrigin
     /** Rejects an absent session instead of interpreting mount uncertainty as create permission. */
     attachOnly?: boolean
     /** Explicit Windows shell override selected by the user (e.g. 'wsl.exe').
@@ -316,10 +313,10 @@ export type DaemonRequest =
   | ShutdownIfIdleRequest
   | DetachRequest
   | GetCwdRequest
-  | GetForegroundProcessRequest
-  | InspectProcessRequest
-  | ConfirmForegroundProcessRequest
-  | ConfirmShellForegroundRequest
+  | ForegroundProcessProtocol.GetForegroundProcessRequest
+  | ForegroundProcessProtocol.InspectProcessRequest
+  | ForegroundProcessProtocol.ConfirmForegroundProcessRequest
+  | ForegroundProcessProtocol.ConfirmShellForegroundRequest
   | ClearScrollbackRequest
   | ShutdownRequest
   | PingRequest

--- a/src/main/ipc/notifications-mobile-fanout.test.ts
+++ b/src/main/ipc/notifications-mobile-fanout.test.ts
@@ -36,6 +36,35 @@ describe('registerNotificationHandlers', () => {
     resetNotificationDispatchMocks()
   })
 
+  it('forwards each device origin without showing a host notification or sharing cooldowns', async () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: { enabled: true, agentTaskComplete: true, terminalBell: true }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+    const handler = getDispatchHandler()
+    for (const deviceId of ['a', 'b']) {
+      expect(
+        await handler(
+          {},
+          {
+            source: 'agent-task-complete',
+            worktreeId: 'shared-workspace',
+            workOrigin: { kind: 'paired-device', deviceId }
+          }
+        )
+      ).toEqual({ delivered: false, reason: 'not-recipient' })
+    }
+    expect(
+      dispatchMobileNotification.mock.calls.map(([event]) => event.workOrigin.deviceId)
+    ).toEqual(['a', 'b'])
+    expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
   it('uses rich formatter output for mobile notifications before the native support guard', async () => {
     notificationIsSupportedMock.mockReturnValue(false)
     const dispatchMobileNotification = vi.fn()

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -1,3 +1,4 @@
+import { workOriginAllowsHost } from '../../shared/work-origin'
 import { BrowserWindow, Notification, ipcMain, powerMonitor } from 'electron'
 import { readDesktopAwayState } from '../notifications/desktop-away-state'
 import type { Store } from '../persistence'
@@ -113,8 +114,18 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       _event,
       args: NotificationDispatchRequest
     ): NotificationDispatchResult | Promise<NotificationDispatchResult> => {
+      const workOrigin =
+        args.workOrigin !== undefined
+          ? args.workOrigin
+          : args.worktreeId && args.paneKey
+            ? runtime?.getPaneWorkOrigin?.(args.worktreeId, args.paneKey)
+            : undefined
+      const localRecipient = workOriginAllowsHost(workOrigin)
       // Why: light the tray attention dot before the cooldown/focus/enabled gates so they can't hold it back (clears on window show/restore; see index.ts).
-      if (args.source === 'agent-task-complete' || args.source === 'terminal-bell') {
+      if (
+        localRecipient &&
+        (args.source === 'agent-task-complete' || args.source === 'terminal-bell')
+      ) {
         const activeWindow = BrowserWindow.getAllWindows().find((win) => !win.isDestroyed()) ?? null
         if (!isMainWindowVisible(activeWindow)) {
           setTrayAttention(true)
@@ -135,12 +146,13 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         if (
           reserveNotificationCooldown(
             recentMobileNotifications,
-            JSON.stringify([desktopAllowed, args.source, args.agentState, dedupeKey]),
+            JSON.stringify([workOrigin, desktopAllowed, args.source, args.agentState, dedupeKey]),
             Date.now()
           )
         ) {
           runtime.dispatchMobileNotification({
             type: 'notification',
+            ...(workOrigin !== undefined ? { workOrigin } : {}),
             emittedAt: Date.now(),
             source: args.source,
             ...(!desktopAllowed ? { desktopAllowed: false } : {}),
@@ -153,6 +165,10 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
             ...(args.agentState ? { agentState: args.agentState } : {})
           })
         }
+      }
+
+      if (!localRecipient) {
+        return { delivered: false, reason: 'not-recipient' }
       }
 
       if (!desktopAllowed) {

--- a/src/main/ipc/pty-daemon-spawn-session-identity.test.ts
+++ b/src/main/ipc/pty-daemon-spawn-session-identity.test.ts
@@ -344,6 +344,7 @@ describe('registerPtyHandlers', () => {
           })
         )
         const store = {
+          getWorkspaceSession: vi.fn(() => ({})),
           upsertSshRemotePtyLease: vi.fn(),
           supersedeSshRemotePtyLeasesForBoundPane: vi.fn(),
           persistPtyBinding: vi.fn()
@@ -433,6 +434,7 @@ describe('registerPtyHandlers', () => {
         expect(store.persistPtyBinding).toHaveBeenCalledWith(
           {
             worktreeId: 'wt-1',
+            workOrigin: { kind: 'host' },
             tabId: 'tab-1',
             leafId,
             ptyId: 'ssh-pty'
@@ -466,6 +468,7 @@ describe('registerPtyHandlers', () => {
           throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: remote-pty')
         })
         const store = {
+          getWorkspaceSession: vi.fn(() => ({})),
           markSshRemotePtyLease: vi.fn(),
           clearSshRemotePtyKillIntent: vi.fn()
         }
@@ -523,6 +526,7 @@ describe('registerPtyHandlers', () => {
           throw new Error('SSH_SESSION_EXPIRED: remote-pty')
         })
         const store = {
+          getWorkspaceSession: vi.fn(() => ({})),
           markSshRemotePtyLease: vi.fn(),
           clearSshRemotePtyKillIntent: vi.fn()
         }
@@ -579,6 +583,7 @@ describe('registerPtyHandlers', () => {
           throw new SshPtyAbsentFromRelayError('SSH_SESSION_EXPIRED: remote-pty')
         })
         const store = {
+          getWorkspaceSession: vi.fn(() => ({})),
           markSshRemotePtyLease: vi.fn(),
           clearSshRemotePtyKillIntent: vi.fn()
         }

--- a/src/main/ipc/pty/ipc/spawn-commit-persist.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit-persist.ts
@@ -114,6 +114,10 @@ export async function persistPtyIpcSpawnCommit(ctx: PtyIpcSpawnState): Promise<{
         tabId: args.tabId,
         leafId: ctx.validatedLeafId,
         ptyId: ctx.result.id,
+        workOrigin:
+          ctx.result.isReattach || ctx.stablePaneOwner
+            ? ctx.result.workOrigin
+            : ctx.spawnOptions.workOrigin,
         ...(ctx.result.incarnationId ? { incarnationId: ctx.result.incarnationId } : {}),
         ...(ctx.cwd ? { startupCwd: ctx.cwd } : {})
       }

--- a/src/main/ipc/pty/ipc/spawn-commit.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit.ts
@@ -112,6 +112,10 @@ export async function commitPtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<PtySpawn
         ctx.metadataLeafId !== null
         ? {
             tabId: args.tabId,
+            workOrigin:
+              ctx.result.isReattach || ctx.stablePaneOwner
+                ? ctx.result.workOrigin
+                : ctx.spawnOptions.workOrigin,
             leafId: ctx.metadataLeafId,
             ...(ctx.preAllocatedHandle ? { terminalHandle: ctx.preAllocatedHandle } : {}),
             ...(ctx.result.incarnationId ? { incarnationId: ctx.result.incarnationId } : {}),

--- a/src/main/ipc/pty/ipc/spawn-options.ts
+++ b/src/main/ipc/pty/ipc/spawn-options.ts
@@ -1,3 +1,4 @@
+import { resolvePtySpawnWorkOrigin } from '../pane/pty-work-origin'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { CLAUDE_AUTH_ENV_VARS } from '../../../claude-accounts/environment'
 import { LEGACY_TERMINAL_SHIM_REMOTE_ENV_KEYS } from '../../../pty/legacy-terminal-shim-dir'
@@ -75,6 +76,7 @@ export async function buildPtyIpcSpawnOptions(
   if (args.startupCommandDelivery !== undefined) {
     ctx.spawnOptions.startupCommandDelivery = args.startupCommandDelivery
   }
+  ctx.spawnOptions.workOrigin = resolvePtySpawnWorkOrigin(args, ctx.deps.store)
   if (isTuiAgent(args.launchAgent)) {
     ctx.spawnOptions.launchAgent = args.launchAgent
   }

--- a/src/main/ipc/pty/ipc/spawn-types.ts
+++ b/src/main/ipc/pty/ipc/spawn-types.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../../../shared/work-origin'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type {
   AgentProviderSessionMetadata,
@@ -34,6 +35,7 @@ export type PtySpawnIpcArgs = {
   launchConfig?: SleepingAgentLaunchConfig
   resumeProviderSession?: AgentProviderSessionMetadata
   launchToken?: unknown
+  workOrigin?: WorkOrigin
   launchAgent?: TuiAgent
   startupCommandDelivery?: StartupCommandDelivery
   connectionId?: string | null
@@ -97,6 +99,7 @@ export type PtySpawnIpcDeps = {
   localStartupCwdDirectoryExists: (path: string) => boolean
   prepareCodexResumeHome: (args: {
     connectionId?: string | null
+    workOrigin?: WorkOrigin
     launchAgent?: TuiAgent
     providerSession?: AgentProviderSessionMetadata
     target: CodexAccountSelectionTarget

--- a/src/main/ipc/pty/pane/pty-work-origin.test.ts
+++ b/src/main/ipc/pty/pane/pty-work-origin.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePtySpawnWorkOrigin } from './pty-work-origin'
+import { preserveRuntimeAuthoredWorkspaceSessionFields } from '../../../persistence/runtime-authored-workspace-session-fields'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+
+const paired = { kind: 'paired-device', deviceId: 'a' } as const
+
+describe('terminal work origin', () => {
+  it('retains sleeping pane attribution and honors a new explicit launch including unknown', () => {
+    const store = {
+      getWorkspaceSession: () => ({ terminalWorkOriginsByPaneKey: { 'tab:leaf': paired } })
+    } as never
+    expect(resolvePtySpawnWorkOrigin({ tabId: 'tab', leafId: 'leaf' }, store)).toEqual(paired)
+    expect(
+      resolvePtySpawnWorkOrigin({ tabId: 'tab', leafId: 'leaf', workOrigin: null }, store)
+    ).toBeNull()
+    expect(resolvePtySpawnWorkOrigin({ tabId: 'new', leafId: 'leaf' }, store)).toEqual({
+      kind: 'host'
+    })
+  })
+
+  it('preserves old writer omissions while allowing trusted retirement', () => {
+    const prior = {
+      terminalWorkOriginsByPaneKey: { 'tab:leaf': paired }
+    } as unknown as WorkspaceSessionState
+    expect(
+      preserveRuntimeAuthoredWorkspaceSessionFields({} as unknown as WorkspaceSessionState, prior)
+        .terminalWorkOriginsByPaneKey
+    ).toEqual(prior.terminalWorkOriginsByPaneKey)
+    expect(
+      preserveRuntimeAuthoredWorkspaceSessionFields(
+        { terminalWorkOriginsByPaneKey: {} } as unknown as WorkspaceSessionState,
+        prior
+      ).terminalWorkOriginsByPaneKey
+    ).toEqual({})
+  })
+})

--- a/src/main/ipc/pty/pane/pty-work-origin.ts
+++ b/src/main/ipc/pty/pane/pty-work-origin.ts
@@ -1,0 +1,32 @@
+import type { RuntimePtySpawnState } from '../runtime/spawn-state'
+import { normalizeWorkOrigin, type WorkOrigin } from '../../../../shared/work-origin'
+import { toSshExecutionHostId } from '../../../../shared/execution-host'
+import type { Store } from '../../../persistence'
+
+export function resolvePtySpawnWorkOrigin(
+  args: { workOrigin?: WorkOrigin; tabId?: string; leafId?: string; connectionId?: string | null },
+  store: Store | undefined
+): WorkOrigin {
+  if (args.workOrigin !== undefined) {
+    return normalizeWorkOrigin(args.workOrigin) ?? null
+  }
+  const session =
+    args.tabId && args.leafId
+      ? store?.getWorkspaceSession(
+          args.connectionId ? toSshExecutionHostId(args.connectionId) : undefined
+        )
+      : undefined
+  const retained =
+    args.tabId && args.leafId
+      ? session?.terminalWorkOriginsByPaneKey?.[`${args.tabId}:${args.leafId}`]
+      : undefined
+  return retained === undefined ? { kind: 'host' } : retained
+}
+
+export function resolveCommittedPtyWorkOrigin(ctx: RuntimePtySpawnState): WorkOrigin | undefined {
+  return ctx.result.isReattach ||
+    ctx.stablePaneOwner ||
+    ctx.result.agentSessionEnsure?.disposition === 'adopted'
+    ? ctx.result.workOrigin
+    : ctx.spawnOptions.workOrigin
+}

--- a/src/main/ipc/pty/pane/spawn-reservation.ts
+++ b/src/main/ipc/pty/pane/spawn-reservation.ts
@@ -113,3 +113,14 @@ export function resolvePaneSpawnReservation<T extends PaneSpawnReservationResult
   }
   return response
 }
+
+export function createPaneClaimRelease(claimed?: () => void): () => void {
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    claimed?.()
+  }
+}

--- a/src/main/ipc/pty/pane/stable-owner.ts
+++ b/src/main/ipc/pty/pane/stable-owner.ts
@@ -198,6 +198,7 @@ export function persistAdmittedStablePaneBinding(args: {
       tabId: args.owner.tabId,
       leafId: args.owner.leafId,
       ptyId: args.result.id,
+      workOrigin: args.result.workOrigin,
       ...(args.result.incarnationId ? { incarnationId: args.result.incarnationId } : {}),
       ...(args.startupCwd ? { startupCwd: args.startupCwd } : {}),
       expectedBinding

--- a/src/main/ipc/pty/runtime/spawn-commit.ts
+++ b/src/main/ipc/pty/runtime/spawn-commit.ts
@@ -1,3 +1,4 @@
+import { resolveCommittedPtyWorkOrigin } from '../pane/pty-work-origin'
 import { isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
 import { ptyOwnership, ptyIncarnationById, deletePtyOwnership } from '../provider/ownership-state'
 import { ptySizes } from '../delivery/visibility-state'
@@ -18,11 +19,7 @@ import {
 import { seedTerminalRestoreRecordsFromSpawnResult } from '../pane/agent-session-owners'
 import { track } from '../../../telemetry/client'
 import { getCohortAtEmit } from '../../../telemetry/cohort-classifier'
-import {
-  agentKindSchema,
-  launchSourceSchema,
-  requestKindSchema
-} from '../../../../shared/telemetry-events'
+import * as schemas from '../../../../shared/telemetry-events'
 import { persistAdmittedStablePaneBinding } from '../pane/stable-owner'
 import { claimSshPaneLease } from '../pane/ssh-pane-lease-claim'
 import {
@@ -38,6 +35,7 @@ import type { RuntimePtySpawnState } from './spawn-state'
 
 export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
   const args = ctx.args
+  const workOrigin = resolveCommittedPtyWorkOrigin(ctx)
   const providerReattachLaunchIdentity = admitProviderReattachLaunchIdentity(ctx.result)
   try {
     ctx.stablePaneBindingPersisted = persistAdmittedStablePaneBinding({
@@ -75,6 +73,7 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
         tabId: owner.surface.tabId,
         leafId: owner.surface.leafId,
         terminalHandle: owner.surface.terminalHandle,
+        ...(workOrigin !== undefined ? { workOrigin } : {}),
         ...(ctx.result.incarnationId ? { incarnationId: ctx.result.incarnationId } : {}),
         ...(providerReattachLaunchIdentity ? { providerReattachLaunchIdentity } : {})
       }
@@ -155,6 +154,7 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
         leafId: ctx.hostSessionBinding.leafId,
         ptyId: ctx.result.id,
         hostAdmittedMembership: true,
+        ...(workOrigin !== undefined ? { workOrigin } : {}),
         ...(ctx.result.incarnationId ? { incarnationId: ctx.result.incarnationId } : {}),
         ...(ctx.cwd ? { startupCwd: ctx.cwd } : {}),
         ...(ctx.hostSessionBinding.expectedSourceBinding
@@ -206,6 +206,7 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
         ? {
             tabId: args.tabId,
             leafId: ctx.metadataLeafId,
+            ...(workOrigin !== undefined ? { workOrigin } : {}),
             ...(args.preAllocatedHandle ? { terminalHandle: args.preAllocatedHandle } : {}),
             ...(ctx.result.incarnationId ? { incarnationId: ctx.result.incarnationId } : {}),
             ...(providerReattachLaunchIdentity ? { providerReattachLaunchIdentity } : {})
@@ -229,9 +230,9 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
     markClaudePtySpawned(ctx.result.id)
   }
   if (args.telemetry && !ctx.stablePaneOwner) {
-    const agentKindParse = agentKindSchema.safeParse(args.telemetry.agent_kind)
-    const launchSourceParse = launchSourceSchema.safeParse(args.telemetry.launch_source)
-    const requestKindParse = requestKindSchema.safeParse(args.telemetry.request_kind)
+    const agentKindParse = schemas.agentKindSchema.safeParse(args.telemetry.agent_kind)
+    const launchSourceParse = schemas.launchSourceSchema.safeParse(args.telemetry.launch_source)
+    const requestKindParse = schemas.requestKindSchema.safeParse(args.telemetry.request_kind)
     if (agentKindParse.success && launchSourceParse.success && requestKindParse.success) {
       track('agent_started', {
         agent_kind: agentKindParse.data,

--- a/src/main/ipc/pty/runtime/spawn-options.ts
+++ b/src/main/ipc/pty/runtime/spawn-options.ts
@@ -1,3 +1,4 @@
+import { resolvePtySpawnWorkOrigin } from '../pane/pty-work-origin'
 import type { IPtyProvider, PtySpawnResult } from '../../../providers/types'
 import { LocalPtyProvider } from '../../../providers/local-pty-provider'
 import { makePaneKey, isTerminalLeafId } from '../../../../shared/stable-pane-id'
@@ -99,6 +100,7 @@ export async function buildRuntimePtySpawnOptions(
   if (args.startupCommandDelivery !== undefined) {
     ctx.spawnOptions.startupCommandDelivery = args.startupCommandDelivery
   }
+  ctx.spawnOptions.workOrigin = resolvePtySpawnWorkOrigin(args, ctx.deps.store)
   if (isTuiAgent(args.launchAgent)) {
     ctx.spawnOptions.launchAgent = args.launchAgent
   }

--- a/src/main/ipc/pty/runtime/spawn-state.ts
+++ b/src/main/ipc/pty/runtime/spawn-state.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../../../shared/work-origin'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../../../providers/types'
 import type { CodexPaneHomeRoute } from '../../../codex/codex-pane-account-registry'
 import type { CodexAccountSelectionTarget } from '../../../codex-accounts/runtime-selection'
@@ -86,6 +87,7 @@ export type RuntimePtySpawnArgs = {
   cwd?: string
   command?: string
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   commandDelivery?: 'renderer' | 'provider'
   startupCommandDelivery?: StartupCommandDelivery
   telemetry?: {

--- a/src/main/ipc/session.ts
+++ b/src/main/ipc/session.ts
@@ -14,11 +14,13 @@ export function registerSessionHandlers(store: Store): void {
   })
 
   ipcMain.handle('session:set', (_event, args: WorkspaceSessionState, hostId?: string | null) => {
-    store.setWorkspaceSession(args, hostId)
+    const { terminalWorkOriginsByPaneKey: _origin, ...session } = args
+    store.setWorkspaceSession(session, hostId)
   })
 
   ipcMain.handle('session:patch', (_event, args: WorkspaceSessionPatch, hostId?: string | null) => {
-    store.patchWorkspaceSession(args, hostId)
+    const { terminalWorkOriginsByPaneKey: _origin, ...patch } = args
+    store.patchWorkspaceSession(patch, hostId)
   })
 
   ipcMain.handle('session:flush', () => {
@@ -32,7 +34,8 @@ export function registerSessionHandlers(store: Store): void {
   // data (including terminal scrollback buffers) is persisted to disk
   // before the window closes — regardless of before-quit ordering.
   ipcMain.on('session:set-sync', (event, args: WorkspaceSessionState, hostId?: string | null) => {
-    store.setWorkspaceSession(args, hostId)
+    const { terminalWorkOriginsByPaneKey: _origin, ...session } = args
+    store.setWorkspaceSession(session, hostId)
     store.flush()
     event.returnValue = true
   })

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../../shared/work-origin'
 // Attach: reserve the session record, then open its journal.
 //
 // `create` and `ensure` are the same transition with a different starting
@@ -53,6 +54,7 @@ import { structuredAgentSessionRefusalMessage } from './structured-agent-session
  * session. The host fills them in.
  */
 export type AgentSessionAttachParams = {
+  workOrigin?: WorkOrigin
   envelope: AgentSessionMutationEnvelope
   location: AgentSessionExecutionLocation
   provider: AgentSessionHandleProvider
@@ -248,6 +250,7 @@ export function reserveRequestFor(input: {
   const { params, authority } = input
   return {
     sessionId: input.sessionId,
+    workOrigin: params.workOrigin,
     location: params.location,
     provider: params.provider,
     accountHome: params.accountHome,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -54,6 +54,23 @@ import { StructuredAgentSessionClientDelivery } from './structured-agent-session
 export type { StructuredAgentSessionHostDeps } from './structured-agent-session-host-types'
 
 export class StructuredAgentSessionHost {
+  getWorkOrigin(sessionId: string) {
+    return this.deps.store.getRecord(sessionId)?.workOrigin
+  }
+
+  resolveChildWorkOrigin(sessionId: string, spawnToken: string) {
+    const record = this.deps.store.getRecord(sessionId)
+    if (
+      !record ||
+      !spawnToken ||
+      record.lease.claimStatus !== 'live' ||
+      record.lease.ownerProcess?.spawnToken !== spawnToken
+    ) {
+      return null
+    }
+    return record.workOrigin ?? null
+  }
+
   private readonly conversationCommands = new StructuredConversationCommandController(
     () => this.mutationContext(),
     this

--- a/src/main/orca-profiles/profile-project-session-field-disposition.ts
+++ b/src/main/orca-profiles/profile-project-session-field-disposition.ts
@@ -109,6 +109,10 @@ export const WORKSPACE_SESSION_FIELD_DISPOSITION = {
   // the record's worktreeId on worktree and project removal. Moving a project between profiles runs
   // removeSourceRepo, which has no owner scan, so these records leak there.
   sleepingAgentSessionsByPaneKey: { onRepoRemoval: 'notRepoScoped', onTransfer: 'notTransferred' },
+  terminalWorkOriginsByPaneKey: {
+    onRepoRemoval: 'prunedByBespokeRule',
+    onTransfer: 'copiedByBespokeRule'
+  },
   terminalPtyIncarnationsByPaneKey: {
     onRepoRemoval: 'prunedByBespokeRule',
     onTransfer: 'copiedByBespokeRule'

--- a/src/main/orca-profiles/profile-project-session-state.ts
+++ b/src/main/orca-profiles/profile-project-session-state.ts
@@ -86,6 +86,10 @@ export function mergeWorkspaceSessions(
       ...base.defaultTerminalTabsAppliedByWorktreeId,
       ...incoming.defaultTerminalTabsAppliedByWorktreeId
     },
+    terminalWorkOriginsByPaneKey: {
+      ...base.terminalWorkOriginsByPaneKey,
+      ...incoming.terminalWorkOriginsByPaneKey
+    },
     terminalPtyIncarnationsByPaneKey: {
       ...base.terminalPtyIncarnationsByPaneKey,
       ...incoming.terminalPtyIncarnationsByPaneKey
@@ -163,6 +167,14 @@ export function removeRepoFromWorkspaceSession(
   if (next.terminalPtyIncarnationsByPaneKey) {
     next.terminalPtyIncarnationsByPaneKey = Object.fromEntries(
       Object.entries(next.terminalPtyIncarnationsByPaneKey).filter(([paneKey]) => {
+        const separator = paneKey.lastIndexOf(':')
+        return separator < 1 || !removedTerminalTabIds.has(paneKey.slice(0, separator))
+      })
+    )
+  }
+  if (next.terminalWorkOriginsByPaneKey) {
+    next.terminalWorkOriginsByPaneKey = Object.fromEntries(
+      Object.entries(next.terminalWorkOriginsByPaneKey).filter(([paneKey]) => {
         const separator = paneKey.lastIndexOf(':')
         return separator < 1 || !removedTerminalTabIds.has(paneKey.slice(0, separator))
       })

--- a/src/main/orca-profiles/profile-project-session-transfer.ts
+++ b/src/main/orca-profiles/profile-project-session-transfer.ts
@@ -121,6 +121,12 @@ export function extractSessionForTransfer(
       return separator > 0 && copiedTerminalTabIds.has(paneKey.slice(0, separator))
     })
   )
+  transferred.terminalWorkOriginsByPaneKey = Object.fromEntries(
+    Object.entries(source.terminalWorkOriginsByPaneKey ?? {}).filter(([paneKey]) => {
+      const separator = paneKey.lastIndexOf(':')
+      return separator > 0 && copiedTerminalTabIds.has(paneKey.slice(0, separator))
+    })
+  )
   transferred.terminalSurfaceTombstonesByPaneKey = Object.fromEntries(
     Object.entries(source.terminalSurfaceTombstonesByPaneKey ?? {}).flatMap(
       ([paneKey, tombstone]) =>

--- a/src/main/persistence/loading-store/pty-binding-persistence.ts
+++ b/src/main/persistence/loading-store/pty-binding-persistence.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../../shared/work-origin'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import { isTerminalLeafId } from '../../../shared/stable-pane-id'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
@@ -41,6 +42,7 @@ export class PtyBindingPersistenceOperations {
       leafId: string
       ptyId: string
       incarnationId?: string
+      workOrigin?: WorkOrigin
       startupCwd?: string
       expectedBinding?: { ptyId: string; incarnationId?: string }
       expectedSourceBinding?: PtyBindingSourceExpectation
@@ -161,6 +163,12 @@ export class PtyBindingPersistenceOperations {
           ...this[ptyBindingPersistenceOperationsContext].runtime.state.workspaceSessionsByHostId,
           [resolvedHostId]: sessionBeforeBinding
         }
+      }
+    }
+    if (args.workOrigin !== undefined) {
+      session.terminalWorkOriginsByPaneKey = {
+        ...session.terminalWorkOriginsByPaneKey,
+        [paneKey]: args.workOrigin
       }
     }
     if (args.incarnationId) {

--- a/src/main/persistence/restoring-sessions/session-owner-removal.ts
+++ b/src/main/persistence/restoring-sessions/session-owner-removal.ts
@@ -23,6 +23,14 @@ export function deleteScannedSessionFieldsForOwners(
       })
     )
   }
+  if (next.terminalWorkOriginsByPaneKey) {
+    next.terminalWorkOriginsByPaneKey = Object.fromEntries(
+      Object.entries(next.terminalWorkOriginsByPaneKey).filter(([paneKey]) => {
+        const separator = paneKey.lastIndexOf(':')
+        return separator < 1 || !removedTabIds.has(paneKey.slice(0, separator))
+      })
+    )
+  }
   if (next.terminalSurfaceTombstonesByPaneKey) {
     next.terminalSurfaceTombstonesByPaneKey = Object.fromEntries(
       Object.entries(next.terminalSurfaceTombstonesByPaneKey).filter(

--- a/src/main/persistence/restoring-sessions/session-worktree-ownership.ts
+++ b/src/main/persistence/restoring-sessions/session-worktree-ownership.ts
@@ -50,6 +50,7 @@ export const WORKSPACE_SESSION_WORKTREE_REFERENCE_KIND = {
   defaultTerminalTabsAppliedByWorktreeId: 'owner-keyed',
   sleepingAgentSessionsByPaneKey: 'row-record',
   terminalPtyIncarnationsByPaneKey: 'none',
+  terminalWorkOriginsByPaneKey: 'none',
   terminalTopologyRevisionByRepoId: 'none',
   terminalSurfaceTombstonesByPaneKey: 'row-record',
   closedTerminalTabTombstonesByTabId: 'row-record'

--- a/src/main/persistence/runtime-authored-workspace-session-fields.ts
+++ b/src/main/persistence/runtime-authored-workspace-session-fields.ts
@@ -20,6 +20,12 @@ export function preserveRuntimeAuthoredWorkspaceSessionFields(
   prior: WorkspaceSessionState | null | undefined
 ): WorkspaceSessionState {
   if (
+    next.terminalWorkOriginsByPaneKey === undefined &&
+    prior?.terminalWorkOriginsByPaneKey !== undefined
+  ) {
+    next = { ...next, terminalWorkOriginsByPaneKey: prior.terminalWorkOriginsByPaneKey }
+  }
+  if (
     next.clientHostedBrowserPagesByWorktree !== undefined ||
     prior?.clientHostedBrowserPagesByWorktree === undefined
   ) {

--- a/src/main/providers/local-pty-session-activation.ts
+++ b/src/main/providers/local-pty-session-activation.ts
@@ -190,6 +190,7 @@ export function activateLocalPtySession(args: {
   return {
     id,
     incarnationId,
+    workOrigin: spawn.workOrigin,
     pid,
     ...(spawnedWslDistro !== undefined ? { wslDistro: spawnedWslDistro } : {})
   }

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { PtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
@@ -58,6 +59,7 @@ export type PtySpawnOptions = {
   startupCommandDelivery?: StartupCommandDelivery
   /** Minimal allowlisted launch ownership preserved by daemon reattach. */
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   /** Orca worktree identity. When present, the local provider scopes shell
    *  history to this worktree so ArrowUp only surfaces local commands. */
   worktreeId?: string

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { AgentSessionClaimedSpawnResult } from '../../shared/agent-session-host-authority'
@@ -29,6 +30,7 @@ export type PtySpawnResult = {
   pid?: number | null
   /** Minimal allowlisted launch ownership returned by daemon reattach. */
   launchAgent?: TuiAgent
+  workOrigin?: WorkOrigin
   /** Local WSL context: null is native; undefined is unavailable/legacy. */
   wslDistro?: string | null
   /** ANSI snapshot of the terminal screen, present when reattaching to an

--- a/src/main/providers/ssh-pty-session-reattach.ts
+++ b/src/main/providers/ssh-pty-session-reattach.ts
@@ -1,3 +1,4 @@
+import { normalizeWorkOrigin, type WorkOrigin } from '../../shared/work-origin'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { isPtyIncarnationId, type PtyIncarnationId } from '../../shared/pty-incarnation'
 import {
@@ -24,6 +25,7 @@ import {
 import type { SshPtyReceivingActivationLease } from './ssh-pty-notification-routing'
 
 export type SshPtyAttachResult = {
+  workOrigin?: WorkOrigin
   replay?: string
   incarnationId?: PtyIncarnationId
   sourceRecovery?: PtySourceRecoveryResult
@@ -44,6 +46,7 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
     throw new Error('Invalid SSH PTY attach response')
   }
   const result = value as {
+    workOrigin?: unknown
     replay?: unknown
     incarnationId?: unknown
     sourceRecovery?: unknown
@@ -69,6 +72,7 @@ export function parseSshPtyAttachResult(value: unknown): SshPtyAttachResult {
     throw new Error('Invalid SSH PTY source activation identity')
   }
   return {
+    workOrigin: normalizeWorkOrigin(result.workOrigin),
     ...(typeof result.replay === 'string' ? { replay: result.replay } : {}),
     ...(isPtyIncarnationId(result.incarnationId) ? { incarnationId: result.incarnationId } : {}),
     ...(sourceRecovery ? { sourceRecovery } : {}),
@@ -219,6 +223,7 @@ export async function reattachSshPtySession(args: {
     return {
       id: toAppSshPtyId(args.connectionId, relaySessionId),
       isReattach: true,
+      workOrigin: attachResult.workOrigin,
       ...(attachResult.replay ? { replay: attachResult.replay } : {}),
       ...(attachResult.incarnationId ? { incarnationId: attachResult.incarnationId } : {}),
       ...(attachResult.sourceRecovery ? { sourceRecovery: attachResult.sourceRecovery } : {}),

--- a/src/main/providers/ssh-pty-spawn-request.ts
+++ b/src/main/providers/ssh-pty-spawn-request.ts
@@ -10,6 +10,7 @@ export function buildSshPtySpawnRequest(args: {
 }): Record<string, unknown> {
   const { options } = args
   return {
+    workOrigin: options.workOrigin,
     cols: options.cols,
     rows: options.rows,
     cwd: options.cwd,

--- a/src/main/runtime/agent-session-reservation-admission.ts
+++ b/src/main/runtime/agent-session-reservation-admission.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 /**
  * Reservation admission: what a reserve request means against the persisted state.
  *
@@ -44,6 +45,7 @@ import {
 import type { AgentSessionStoreState } from './agent-session-record-store-file'
 
 export type AgentSessionReserveRequest = {
+  workOrigin?: WorkOrigin
   sessionId: string
   location: AgentSessionExecutionLocation
   provider: AgentSessionHandleProvider
@@ -238,6 +240,7 @@ function createAgentSessionRecord(
 ): AgentSessionRecord {
   return {
     schemaVersion: AGENT_SESSION_RECORD_SCHEMA_VERSION,
+    workOrigin: request.workOrigin,
     sessionId: request.sessionId,
     location: request.location,
     provider: request.provider,

--- a/src/main/runtime/mobile-session-terminal-persistence-retirement.ts
+++ b/src/main/runtime/mobile-session-terminal-persistence-retirement.ts
@@ -43,6 +43,8 @@ function recordTerminalSurfaceRetirement(
   surface: RetiredTerminalSurface,
   paneKey: string
 ): WorkspaceSessionState {
+  const terminalWorkOriginsByPaneKey = { ...session.terminalWorkOriginsByPaneKey }
+  delete terminalWorkOriginsByPaneKey[paneKey]
   const terminalPtyIncarnationsByPaneKey = {
     ...session.terminalPtyIncarnationsByPaneKey
   }
@@ -55,6 +57,7 @@ function recordTerminalSurfaceRetirement(
     {
       ...session,
       terminalPtyIncarnationsByPaneKey,
+      terminalWorkOriginsByPaneKey,
       terminalSurfaceTombstonesByPaneKey
     },
     surface.worktreeId

--- a/src/main/runtime/mobile-session-terminal-projection.ts
+++ b/src/main/runtime/mobile-session-terminal-projection.ts
@@ -34,6 +34,9 @@ export function buildHeadlessMobileSessionTerminalTabs(
             type: 'terminal' as const,
             id: `${tab.id}::${leafId}`,
             parentTabId: tab.id,
+            ...(session.terminalWorkOriginsByPaneKey?.[`${tab.id}:${leafId}`] !== undefined
+              ? { workOrigin: session.terminalWorkOriginsByPaneKey[`${tab.id}:${leafId}`] }
+              : {}),
             leafId,
             title,
             ...(ptyId ? { ptyId } : {}),

--- a/src/main/runtime/multi-client-navigation-isolation.integration.test.ts
+++ b/src/main/runtime/multi-client-navigation-isolation.integration.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { parsePairingCode } from '../../shared/pairing'
-import type { RuntimeMobileSessionTabsResult } from '../../shared/runtime-types'
 import type { PersistedMobileClientTabSelections } from '../../shared/persisted-state-types'
 import { OrcaRuntimeService } from './orca-runtime'
 import { OrcaRuntimeRpcServer } from './runtime-rpc'
@@ -343,6 +342,10 @@ describe('paired runtime navigation isolation', () => {
     const harness = await startHarness()
     await subscribeBothClientEventStreams(harness)
 
+    vi.spyOn(harness.runtime, 'getTerminalWorkOrigin').mockReturnValue({
+      kind: 'paired-device',
+      deviceId: harness.deviceIdA
+    })
     // The observer is offline while the creator works.
     harness.readerB.dispose()
     await new Promise<void>((resolve) => {
@@ -359,7 +362,9 @@ describe('paired runtime navigation isolation', () => {
         repo: FOLDER_REPO_ID,
         name: 'offline-observer-workspace',
         activate: true,
-        navigation: 'all'
+        navigation: 'all',
+        callerTerminalHandle: 'parent-terminal',
+        cliProvenanceRequest: {}
       }
     })
     await expect(harness.readerA.next('create-while-b-offline')).resolves.toMatchObject({
@@ -397,34 +402,52 @@ describe('paired runtime navigation isolation', () => {
     expect(observed.at(-1)).toBe('reposChanged')
   })
 
-  it('still reveals to every client when a paired caller asks for all-surface navigation', async () => {
-    // Why: the CLI pairs as a runtime device but has no viewer of its own, so
-    // `orca worktree create --activate` against a remote runtime sends navigation 'all'.
-    const harness = await startHarness()
-    await subscribeBothClientEventStreams(harness)
-
-    send(harness.clientA, {
-      id: 'cli-shaped-create',
-      method: 'worktree.create',
-      params: {
-        repo: FOLDER_REPO_ID,
-        name: 'cli-shaped-workspace',
-        activate: true,
-        navigation: 'all'
+  it.each([false, true])(
+    'isolates current and legacy CLI activation (headless=%s)',
+    async (headless) => {
+      const harness = await startHarness({ headless })
+      await subscribeBothClientEventStreams(harness)
+      const deviceId = harness.deviceIdA
+      vi.spyOn(harness.runtime, 'getTerminalWorkOrigin').mockReturnValue({
+        kind: 'paired-device',
+        deviceId
+      })
+      for (const legacy of [false, true]) {
+        const id = `cli-create-${legacy}`
+        send(harness.clientA, {
+          id,
+          method: 'worktree.create',
+          params: {
+            repo: FOLDER_REPO_ID,
+            name: id,
+            activate: true,
+            callerTerminalHandle: 'parent-terminal',
+            cliProvenanceRequest: {},
+            ...(legacy ? {} : { navigation: 'all' })
+          }
+        })
+        await expect(harness.readerA.next(id)).resolves.toMatchObject({ ok: true })
+        await expect(
+          harness.readerA.next(
+            'events-a',
+            (response) => resultType(response) === 'activateWorktree'
+          )
+        ).resolves.toMatchObject({ ok: true })
+        harness.runtime.notifyReposChangedForRemoteClients()
+        const observed: string[] = []
+        for (;;) {
+          const type = resultType(await harness.readerB.next('events-b'))
+          observed.push(type ?? 'unknown')
+          if (type === 'reposChanged') {
+            break
+          }
+        }
+        expect(observed).not.toContain('activateWorktree')
+        expect(observed).toContain('worktreesChanged')
+        expect(harness.activateWorktree).not.toHaveBeenCalled()
       }
-    })
-    await expect(harness.readerA.next('cli-shaped-create')).resolves.toMatchObject({ ok: true })
-
-    const [eventA, eventB] = await Promise.all([
-      harness.readerA.next('events-a', (response) => resultType(response) === 'activateWorktree'),
-      harness.readerB.next('events-b', (response) => resultType(response) === 'activateWorktree')
-    ])
-    expect([resultType(eventA), resultType(eventB)]).toEqual([
-      'activateWorktree',
-      'activateWorktree'
-    ])
-    expect(harness.activateWorktree).toHaveBeenCalled()
-  })
+    }
+  )
 
   it('keeps create activation caller-scoped on a headless orca serve host', async () => {
     const harness = await startHarness({ headless: true })
@@ -449,20 +472,19 @@ describe('paired runtime navigation isolation', () => {
     expect(observed).not.toContain('activateWorktree')
     expect(observed).toContain('worktreesChanged')
 
-    // A headless host with no viewer of its own still reveals an in-process/CLI create.
     await harness.runtime.createManagedWorktree({
       repoSelector: `id:${FOLDER_REPO_ID}`,
       name: 'headless-cli-workspace',
       activate: true
     })
-    expect(
-      resultType(
-        await harness.readerB.next(
-          'events-b',
-          (response) => resultType(response) === 'activateWorktree'
-        )
-      )
-    ).toBe('activateWorktree')
+    harness.runtime.notifyReposChangedForRemoteClients()
+    for (;;) {
+      const type = resultType(await harness.readerB.next('events-b'))
+      expect(type).not.toBe('activateWorktree')
+      if (type === 'reposChanged') {
+        break
+      }
+    }
   })
 
   it('normalizes a paired focused terminal.create before host-renderer activation', async () => {
@@ -502,27 +524,28 @@ describe('paired runtime navigation isolation', () => {
     })
   })
 
-  it('still reveals a host-originated create-with-activate on the host and every client', async () => {
+  it('reveals a host-originated create only on the host', async () => {
     const harness = await startHarness()
     await subscribeBothClientEventStreams(harness)
-
-    // Why: a headless server's only viewer is a remote client, so an in-process/CLI
-    // create must keep reaching clients; only paired-client callers are scoped.
     await harness.runtime.createManagedWorktree({
       repoSelector: `id:${FOLDER_REPO_ID}`,
-      name: 'cli-created-workspace',
+      name: 'host-created',
       activate: true
     })
-
-    const [eventA, eventB] = await Promise.all([
-      harness.readerA.next('events-a', (response) => resultType(response) === 'activateWorktree'),
-      harness.readerB.next('events-b', (response) => resultType(response) === 'activateWorktree')
-    ])
-    expect([resultType(eventA), resultType(eventB)]).toEqual([
-      'activateWorktree',
-      'activateWorktree'
-    ])
-    expect(harness.activateWorktree).toHaveBeenCalled()
+    harness.runtime.notifyReposChangedForRemoteClients()
+    for (const [reader, id] of [
+      [harness.readerA, 'events-a'],
+      [harness.readerB, 'events-b']
+    ] as const) {
+      for (;;) {
+        const type = resultType(await reader.next(id))
+        expect(type).not.toBe('activateWorktree')
+        if (type === 'reposChanged') {
+          break
+        }
+      }
+    }
+    expect(harness.activateWorktree).toHaveBeenCalledOnce()
   })
 
   it('projects session-tab activation only to the paired caller across fanout and reconnect', async () => {
@@ -631,7 +654,7 @@ describe('paired runtime navigation isolation', () => {
     harness.runtime.notifyWorktreesChangedForRemoteClients(REPO_ID)
     expect(resultType(await harness.readerA.next('events-a'))).toBe('worktreesChanged')
     expect(resultType(await harness.readerB.next('events-b'))).toBe('worktreesChanged')
-    expect(harness.hostSelections.worktreeId).toBe(CLIENT_A_WORKTREE_ID)
+    expect(harness.hostSelections.worktreeId).toBe(HOST_WORKTREE_ID)
 
     send(harness.clientB, {
       id: 'clients-follow',
@@ -639,15 +662,13 @@ describe('paired runtime navigation isolation', () => {
       params: { worktree: `id:${CLIENT_B_WORKTREE_ID}`, navigation: 'clients' }
     })
     await harness.readerB.next('clients-follow')
+    harness.runtime.notifyReposChangedForRemoteClients()
     const [eventA, eventB] = await Promise.all([
       harness.readerA.next('events-a'),
       harness.readerB.next('events-b')
     ])
-    expect([resultType(eventA), resultType(eventB)]).toEqual([
-      'activateWorktree',
-      'activateWorktree'
-    ])
-    expect(harness.hostSelections.worktreeId).toBe(CLIENT_A_WORKTREE_ID)
+    expect([resultType(eventA), resultType(eventB)]).toEqual(['reposChanged', 'reposChanged'])
+    expect(harness.hostSelections.worktreeId).toBe(HOST_WORKTREE_ID)
 
     for (const [session, id] of [
       [harness.clientA, 'tabs-a'],
@@ -675,7 +696,7 @@ describe('paired runtime navigation isolation', () => {
         await harness.readerA.next('tabs-a', (response) => resultType(response) === 'updated')
       )
     ).toBe('client-a-tab')
-    expect(harness.hostSelections.tabId).toBe('client-a-tab')
+    expect(harness.hostSelections.tabId).toBe('host-tab')
 
     send(harness.clientB, {
       id: 'tabs-clients-follow',
@@ -687,18 +708,18 @@ describe('paired runtime navigation isolation', () => {
       }
     })
     await harness.readerB.next('tabs-clients-follow')
-    const [tabsA, tabsB] = await Promise.all([
-      harness.readerA.next('tabs-a', (response) => resultType(response) === 'updated'),
-      harness.readerB.next('tabs-b', (response) => resultType(response) === 'updated')
-    ])
-    expect([activeTabId(tabsA), activeTabId(tabsB)]).toEqual(['client-b-tab', 'client-b-tab'])
-    expect(
-      [tabsA, tabsB].map(
-        (response) =>
-          (response.result as RuntimeMobileSessionTabsResult | undefined)?.navigationIntent
-      )
-    ).toEqual(['follow', 'follow'])
-    expect(harness.hostSelections.tabId).toBe('client-a-tab')
+    const tabsB = await harness.readerB.next(
+      'tabs-b',
+      (response) => resultType(response) === 'updated'
+    )
+    send(harness.clientA, {
+      id: 'verify-a-selection',
+      method: 'session.tabs.list',
+      params: { worktree: `id:${SESSION_WORKTREE_ID}` }
+    })
+    const tabsA = await harness.readerA.next('verify-a-selection')
+    expect([activeTabId(tabsA), activeTabId(tabsB)]).toEqual(['client-a-tab', 'client-b-tab'])
+    expect(harness.hostSelections.tabId).toBe('host-tab')
   })
 
   it('isolates crossed clients across two runtime servers', async () => {

--- a/src/main/runtime/orca-runtime-activate-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-activate-managed-worktree.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
+import type { WorkOrigin } from '../../shared/work-origin'
 import { OrcaRuntimeWithListManagedWorktrees } from './orca-runtime-list-managed-worktrees'
 import type { RuntimeNavigationTarget } from '../../shared/runtime-navigation'
 import { navigationTargetsClients, navigationTargetsHost } from '../../shared/runtime-navigation'
@@ -202,6 +203,7 @@ export class OrcaRuntimeWithActivateManagedWorktree extends OrcaRuntimeWithListM
   }
 
   protected async provisionManagedWorktreeTerminals(args: {
+    workOrigin?: WorkOrigin
     worktreeSelector: string
     worktreeId: string
     worktreePath: string
@@ -219,7 +221,7 @@ export class OrcaRuntimeWithActivateManagedWorktree extends OrcaRuntimeWithListM
     // Why: a workspace provisioned in the background must not pull the sidebar
     // to itself; the user never asked to look at these tabs.
     surfaceOwner?: false
-  }): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }> {
+  }): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null; warning?: string }> {
     return provisionWorktreeTerminals(this.getWorktreeTerminalProvisioningHost(), args)
   }
 }

--- a/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
@@ -29,10 +29,12 @@ export class OrcaRuntimeWithCreateManagedRemoteWorktree extends OrcaRuntimeWithC
       canSpawn: () => Boolean(this.ptyController?.spawn),
       markTrusted: (agent, connectionId, path) =>
         this.markRemoteWorkspaceTrustedForAgent(agent, connectionId, path),
-      createTerminal: (selector, options) => this.createTerminal(selector, options),
+      createTerminal: (selector, options) =>
+        this.createTerminal(selector, { ...options, workOrigin: args.workOrigin }),
       pasteDraft: (handle, draft) => this.pasteStartupDraftWhenReady(handle, draft),
       sendFollowup: (handle, followup) => this.sendStartupFollowupWhenReady(handle, followup),
-      provision: (options) => this.provisionManagedWorktreeTerminals(options),
+      provision: (options) =>
+        this.provisionManagedWorktreeTerminals({ ...options, workOrigin: args.workOrigin }),
       activate: (repoId, worktreeId, setup, startup, defaultTabs) =>
         this.notifyActivateWorktree(
           repoId,
@@ -40,7 +42,8 @@ export class OrcaRuntimeWithCreateManagedRemoteWorktree extends OrcaRuntimeWithC
           setup,
           startup,
           defaultTabs,
-          args.navigation
+          args.navigation,
+          args.workOrigin
         ),
       invalidateResolvedWorktrees: () => this.invalidateResolvedWorktreeCache(),
       invalidateWorktreeScan: (repoId) => this.invalidateWorktreeScanCacheForRepo(repoId),

--- a/src/main/runtime/orca-runtime-create-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-worktree.ts
@@ -16,6 +16,10 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
   async createManagedWorktree(
     args: RuntimeManagedWorktreeCreateArgs
   ): Promise<CreateWorktreeResult> {
+    args = {
+      ...args,
+      workOrigin: args.workOrigin === undefined ? { kind: 'host' } : args.workOrigin
+    }
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
@@ -79,7 +83,8 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
         deps: {
           store: this.store,
           ptySpawnAvailable: Boolean(this.ptyController?.spawn),
-          createTerminal: (selector, options) => this.createTerminal(selector, options),
+          createTerminal: (selector, options) =>
+            this.createTerminal(selector, { ...options, workOrigin: args.workOrigin }),
           markTrusted: (agent, path) =>
             this.markWorkspaceTrustedForAgent(agent, sshConnectionId, path),
           pasteDraft: (handle, draft) => this.pasteStartupDraftWhenReady(handle, draft),
@@ -94,7 +99,8 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
               setup,
               startup,
               undefined,
-              args.navigation
+              args.navigation,
+              args.workOrigin
             )
         }
       })
@@ -218,10 +224,12 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
       ports: {
         canSpawn: Boolean(this.ptyController?.spawn),
         markTrusted: (agent, path) => this.markLocalWorkspaceTrustedForAgent(agent, path),
-        createTerminal: (selector, options) => this.createTerminal(selector, options),
+        createTerminal: (selector, options) =>
+          this.createTerminal(selector, { ...options, workOrigin: args.workOrigin }),
         pasteDraft: (handle, draft) => this.pasteStartupDraftWhenReady(handle, draft),
         sendFollowup: (handle, followup) => this.sendStartupFollowupWhenReady(handle, followup),
-        provision: (options) => this.provisionManagedWorktreeTerminals(options),
+        provision: (options) =>
+          this.provisionManagedWorktreeTerminals({ ...options, workOrigin: args.workOrigin }),
         activate: (repoId, worktreeId, activationSetup, startup, activationDefaultTabs) =>
           this.notifyActivateWorktree(
             repoId,
@@ -229,7 +237,8 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
             activationSetup,
             startup,
             activationDefaultTabs,
-            args.navigation
+            args.navigation,
+            args.workOrigin
           )
       }
     })
@@ -272,7 +281,7 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
             }
           }
         : {}),
-      ...(defaultTabs ? { defaultTabs } : {}),
+      ...(defaultTabs && args.workOrigin?.kind === 'host' ? { defaultTabs } : {}),
       ...(warning ? { warning } : {}),
       ...(addResult.localBaseRefRefresh
         ? { localBaseRefRefresh: addResult.localBaseRefRefresh }

--- a/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
 import { OrcaRuntimeWithResolveMobileSessionTerminalCommand } from './orca-runtime-resolve-mobile-session-terminal-command'
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { WorktreeStartupLaunch } from '../../shared/worktree/launch-types'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
@@ -23,6 +24,7 @@ export class OrcaRuntimeWithCreateRuntimeOwnedMobileSessionTerminal extends Orca
     afterTabId?: string,
     opts: {
       command?: string
+      workOrigin?: WorkOrigin
       cwd?: string
       env?: Record<string, string>
       envToDelete?: string[]
@@ -43,6 +45,7 @@ export class OrcaRuntimeWithCreateRuntimeOwnedMobileSessionTerminal extends Orca
     const isNewSession = stableSessionId !== undefined && opts.identity?.sessionId === undefined
     const terminal = await this.createTerminal(`id:${worktreeId}`, {
       focus: false,
+      workOrigin: opts.workOrigin,
       command: opts.command,
       cwd,
       env: opts.env,
@@ -95,6 +98,7 @@ export class OrcaRuntimeWithCreateRuntimeOwnedMobileSessionTerminal extends Orca
       parentTabId,
       leafId,
       ptyId: livePty.pty.ptyId,
+      workOrigin: this.getPaneWorkOrigin(worktreeId, livePty.pty.paneKey, livePty.pty),
       incarnationId: livePty.pty.incarnationId,
       title: terminal.title ?? livePty.pty.title ?? 'Terminal',
       ...(cwd ? { startupCwd: cwd } : {}),

--- a/src/main/runtime/orca-runtime-create-terminal-desktop.ts
+++ b/src/main/runtime/orca-runtime-create-terminal-desktop.ts
@@ -51,6 +51,7 @@ export async function createDesktopTerminal(
     dependencies.getRuntimeDesktopSurface().onIpc('terminal:tabCreateReply', handler)
     win.webContents.send('terminal:requestTabCreate', {
       requestId,
+      workOrigin: launchOpts.workOrigin,
       worktreeId,
       command: launchOpts.command,
       cwd,

--- a/src/main/runtime/orca-runtime-create-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-terminal.ts
@@ -1,4 +1,7 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
+import { createPaneClaimRelease } from '../ipc/pty/pane/spawn-reservation'
+import { revealCreatedTerminal } from './terminal-create-reveal'
+import * as workOriginPolicy from './terminal-create-work-origin'
 import { OrcaRuntimeWithTerminalCreateDeduplication } from './orca-runtime-terminal-create-deduplication'
 import * as dependencies from './orca-runtime-create-terminal-dependencies'
 import { createDesktopTerminal } from './orca-runtime-create-terminal-desktop'
@@ -42,20 +45,20 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
       let tabId = canAdoptPaneIdentity ? (hintedTabId as string) : dependencies.randomUUID()
       let leafId = canAdoptPaneIdentity ? (launchOpts.leafId as string) : dependencies.randomUUID()
       let paneKey = dependencies.makePaneKey(tabId, leafId)
+      const workOrigin = workOriginPolicy.resolveTerminalCreateWorkOrigin(
+        this,
+        workspace.id,
+        paneKey,
+        canAdoptPaneIdentity,
+        launchOpts.workOrigin
+      )
       const claimedStablePaneCreate = this.ptyController.claimStablePaneCreate?.({
         worktreeId: workspace.id,
         connectionId: workspace.connectionId,
         tabId,
         leafId
       })
-      let stablePaneCreateReleased = false
-      const releaseStablePaneCreate = (): void => {
-        if (stablePaneCreateReleased) {
-          return
-        }
-        stablePaneCreateReleased = true
-        claimedStablePaneCreate?.()
-      }
+      const releaseStablePaneCreate = createPaneClaimRelease(claimedStablePaneCreate)
       try {
         if (launchOpts.signal?.aborted) {
           throw new Error('client_disconnected')
@@ -132,6 +135,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
               ? launchOpts.command
               : (agentTeamsPlan?.command ?? launchOpts.command),
             launchAgent: launchOpts.launchAgent,
+            workOrigin,
             commandDelivery: 'provider',
             startupCommandDelivery: launchOpts.startupCommandDelivery,
             env,
@@ -234,6 +238,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
             pty.launchToken = launchToken ?? null
             pty.launchIncarnationId = launchToken ? pty.incarnationId : null
             pty.launchAgent = launchOpts.launchAgent ?? null
+            workOriginPolicy.applyCreatedTerminalWorkOrigin(pty, result, workOrigin)
           }
           pty.tabId = tabId
           pty.paneKey = paneKey
@@ -250,32 +255,26 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
             ...(cwd !== workspace.path ? { startupCwd: cwd } : {})
           })
         }
-        let surface: dependencies.RuntimeTerminalCreate['surface'] = 'background'
-        let warning: string | undefined
-        if (presentation !== 'background' && this.notifier?.revealTerminalSession) {
-          try {
-            await this.notifier.revealTerminalSession(workspace.id, {
-              ptyId: result.id,
-              title: launchOpts.title ?? null,
-              ...(cwd !== workspace.path ? { cwd } : {}),
-              ...(effectiveLaunchConfig ? { launchConfig: effectiveLaunchConfig } : {}),
-              ...(launchToken ? { launchToken } : {}),
-              ...(launchOpts.launchAgent ? { launchAgent: launchOpts.launchAgent } : {}),
-              ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
-              activate: presentation === 'focused',
-              ...(presentation ? { presentation } : {}),
-              ...dependencies.ownerSurfacing(opts.surfaceOwner !== false),
-              tabId,
-              leafId
-            })
-            surface = 'visible'
-          } catch (err) {
-            console.warn(`[terminal-create] failed to create inactive tab for ${result.id}:`, err)
-            warning = dependencies.createTerminalRevealWarning(handle, err)
+        const { surface, warning } = await revealCreatedTerminal(
+          this.notifier,
+          presentation,
+          workspace.id,
+          handle,
+          {
+            ptyId: result.id,
+            title: launchOpts.title ?? null,
+            ...(cwd !== workspace.path ? { cwd } : {}),
+            ...(effectiveLaunchConfig ? { launchConfig: effectiveLaunchConfig } : {}),
+            ...(launchToken ? { launchToken } : {}),
+            ...(launchOpts.launchAgent ? { launchAgent: launchOpts.launchAgent } : {}),
+            ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
+            activate: presentation === 'focused',
+            ...(presentation ? { presentation } : {}),
+            ...dependencies.ownerSurfacing(opts.surfaceOwner !== false),
+            tabId,
+            leafId
           }
-        } else if (presentation !== 'background') {
-          warning = dependencies.createTerminalRevealWarning(handle)
-        }
+        )
         return {
           handle,
           tabId,

--- a/src/main/runtime/orca-runtime-notify-ssh-state-changed.ts
+++ b/src/main/runtime/orca-runtime-notify-ssh-state-changed.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
+import type { WorkOrigin } from '../../shared/work-origin'
 import { OrcaRuntimeWithGetStatus } from './orca-runtime-get-status'
 import type { SshConnectionState } from '../../shared/ssh-types'
 import { getPublicSshState } from './public-ssh-state'
@@ -6,7 +7,6 @@ import { splitWorktreeId } from '../../shared/worktree/id'
 import type { CreateWorktreeResult } from '../../shared/worktree/create-types'
 import type { WorktreeStartupLaunch } from '../../shared/worktree/launch-types'
 import type { RuntimeNavigationTarget } from '../../shared/runtime-navigation'
-import { navigationTargetsClients, navigationTargetsHost } from '../../shared/runtime-navigation'
 import { toRuntimeActivateWorktreeEvent } from '../../shared/runtime-client-events'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import type { BrowserBackend } from '../browser/browser-backend'
@@ -145,14 +145,20 @@ export class OrcaRuntimeWithNotifySshStateChanged extends OrcaRuntimeWithGetStat
     setup?: CreateWorktreeResult['setup'],
     startup?: WorktreeStartupLaunch,
     defaultTabs?: CreateWorktreeResult['defaultTabs'],
-    navigationTarget?: RuntimeNavigationTarget
+    navigationTarget?: RuntimeNavigationTarget,
+    workOrigin: WorkOrigin = null
   ): void {
     const navigation = navigationTarget ?? 'all'
-    if (navigationTargetsHost(navigation)) {
-      this.notifyHostActivateWorktree(repoId, worktreeId, setup, startup, defaultTabs)
+    if (navigation === 'caller') {
+      return
     }
-    if (navigationTargetsClients(navigation)) {
-      this.notifyClientsActivateWorktree(repoId, worktreeId, setup, startup, defaultTabs)
+    if (workOrigin?.kind === 'host') {
+      this.notifyHostActivateWorktree(repoId, worktreeId, setup, startup, defaultTabs)
+    } else if (workOrigin?.kind === 'paired-device') {
+      this.emitClientEvent({
+        ...toRuntimeActivateWorktreeEvent(repoId, worktreeId, setup, startup, defaultTabs),
+        recipientDeviceId: workOrigin.deviceId
+      })
     }
   }
 

--- a/src/main/runtime/orca-runtime-perform-mobile-session-pty-records-refresh.ts
+++ b/src/main/runtime/orca-runtime-perform-mobile-session-pty-records-refresh.ts
@@ -179,6 +179,7 @@ export class OrcaRuntimeWithPerformMobileSessionPtyRecordsRefresh extends OrcaRu
               leafId: tab.leafId,
               sessionId
             },
+            workOrigin: tab.workOrigin,
             cwd: tab.startupCwd,
             command: agentStartup.command,
             env: agentStartup.env,

--- a/src/main/runtime/orca-runtime-prune-mobile-session-tab-group-layout.ts
+++ b/src/main/runtime/orca-runtime-prune-mobile-session-tab-group-layout.ts
@@ -92,6 +92,8 @@ export class OrcaRuntimeWithPruneMobileSessionTabGroupLayout extends OrcaRuntime
       leaves: this.leaves,
       ptysById: this.ptysById,
       getLiveBrowserTabs: (worktreeId) => this.getLiveBrowserTabsByPageId(worktreeId),
+      getWorkOrigin: (worktreeId, paneKey, pty) =>
+        this.getPaneWorkOrigin(worktreeId, paneKey, pty ?? undefined),
       getProviderSessionRows: (paneKey) => this.getAgentProviderSessionRowsForPaneFn?.(paneKey),
       getProviderSessionSnapshot: () => this.getAgentProviderSessionSnapshotFn?.() ?? [],
       getStatusSnapshot: () => this.getAgentStatusSnapshotFn?.() ?? [],

--- a/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
@@ -89,6 +89,7 @@ export class OrcaRuntimeWithPublishPtyBackedMobileSessionTerminal extends OrcaRu
       ptyId: pty.ptyId,
       incarnationId: pty.incarnationId,
       title,
+      workOrigin: this.getPaneWorkOrigin(worktreeId, pty.paneKey, pty),
       ...(pty.launchAgent ? { launchAgent: pty.launchAgent } : {}),
       ...(args.startupCwd ? { startupCwd: args.startupCwd } : {}),
       ...(viewMode ? { viewMode } : {}),

--- a/src/main/runtime/orca-runtime-register-pty.ts
+++ b/src/main/runtime/orca-runtime-register-pty.ts
@@ -1,9 +1,12 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
 import { OrcaRuntimeWithInvalidateAllHandlesForPty } from './orca-runtime-invalidate-all-handles-for-pty'
+import { structuredWorkerIdentities } from './structured-worker-identity'
+import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-registry'
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 import type { TuiAgent } from '../../shared/tui-agent'
 import { isValidTerminalTabId } from '../../shared/terminal-tab-id'
-import { isTerminalLeafId, makePaneKey } from '../../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../shared/stable-pane-id'
 import { isTuiAgent } from '../../shared/tui-agent-config'
 
 export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHandlesForPty {
@@ -15,6 +18,7 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
       tabId: string
       leafId: string
       incarnationId?: PtyIncarnationId
+      workOrigin?: WorkOrigin
       /** Handle allocated for the replacement incarnation, when one is known. */
       terminalHandle?: string
       agentLaunchAuthority?: { launchToken: string; launchAgent: TuiAgent }
@@ -80,6 +84,12 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
       ...(binding && paneKey ? { tabId: binding.tabId, paneKey } : {}),
       ...(binding?.incarnationId ? { incarnationId: binding.incarnationId } : {})
     })
+    if (incarnationChanged) {
+      delete pty.workOrigin
+    }
+    if (binding?.workOrigin !== undefined) {
+      pty.workOrigin = binding.workOrigin
+    }
     const hostScope = this.getOrchestrationCompatibilityHostScope(pty)
     if (paneKey && binding?.incarnationId && hostScope) {
       this._orchestrationDb?.retainReplacedWorkerTerminalResources({
@@ -137,6 +147,48 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
     if (binding && paneKey) {
       this.ensurePtyBackedMobileSurfaceForRendererTab(worktreeId, binding.tabId)
     }
+  }
+
+  getTerminalWorkOrigin(handle: string): WorkOrigin | undefined {
+    const structured = structuredWorkerIdentities.get(handle)
+    if (structured) {
+      return getStructuredAgentSessionHost()?.getWorkOrigin(structured.sessionId)
+    }
+    const live = this.getLivePtyForHandle(handle)
+    if (!live?.pty.connected) {
+      return undefined
+    }
+    return this.getPaneWorkOrigin(live.pty.worktreeId, live.pty.paneKey, live.pty)
+  }
+
+  getPaneWorkOrigin(
+    worktreeId: string,
+    paneKey: string | null,
+    pty?: {
+      workOrigin?: WorkOrigin
+      ptyId?: string
+      incarnationId?: string | null
+      connectionId?: string | null
+    }
+  ): WorkOrigin | undefined {
+    if (pty?.workOrigin !== undefined) {
+      return pty.workOrigin
+    }
+    if (!paneKey) {
+      return undefined
+    }
+    const session = this.getWorkspaceSessionForWorktree(worktreeId)
+    const pane = parsePaneKey(paneKey)
+    if (
+      pty?.ptyId &&
+      pane &&
+      (session?.terminalLayoutsByTabId?.[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId] !== pty.ptyId ||
+        (pty.incarnationId &&
+          session?.terminalPtyIncarnationsByPaneKey?.[paneKey] !== pty.incarnationId))
+    ) {
+      return undefined
+    }
+    return session?.terminalWorkOriginsByPaneKey?.[paneKey]
   }
 
   assertPtyRegistrationAllowed(ptyId: string, incarnationId?: PtyIncarnationId): void {

--- a/src/main/runtime/orca-runtime-run-create-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-run-create-mobile-session-terminal.ts
@@ -36,6 +36,9 @@ export class OrcaRuntimeWithRunCreateMobileSessionTerminal extends OrcaRuntimeWi
     } = {}
   ): Promise<RuntimeMobileSessionCreateTerminalResult> {
     const pairedCreate = Boolean(opts.clientNavigationId)
+    const workOrigin = opts.clientNavigationId
+      ? { kind: 'paired-device', deviceId: opts.clientNavigationId }
+      : { kind: 'host' }
     const graphEpoch = this.captureReadyGraphEpoch()
     const workspace = await this.resolveTerminalWorkspaceLaunchScope(worktreeSelector)
     const worktreeId = workspace.id
@@ -62,6 +65,7 @@ export class OrcaRuntimeWithRunCreateMobileSessionTerminal extends OrcaRuntimeWi
         opts.activate !== false,
         opts.afterTabId,
         {
+          workOrigin,
           command: startupCommand.command,
           cwd,
           env: startupCommand.env,
@@ -117,6 +121,8 @@ export class OrcaRuntimeWithRunCreateMobileSessionTerminal extends OrcaRuntimeWi
         getRuntimeDesktopSurface().onIpc('terminal:tabCreateReply', handler)
         win.webContents.send('terminal:requestTabCreate', {
           requestId,
+          workOrigin,
+          ...(pairedCreate ? { surfaceOwner: false } : {}),
           worktreeId,
           afterTabId: afterDesktopTabId,
           targetGroupId: opts.targetGroupId,
@@ -129,11 +135,11 @@ export class OrcaRuntimeWithRunCreateMobileSessionTerminal extends OrcaRuntimeWi
           ...(opts.viewMode ? { viewMode: opts.viewMode } : {}),
           startupCommandDelivery: startupCommand.startupCommandDelivery,
           source: 'runtime-session',
-          activate: opts.activate
+          activate: pairedCreate ? false : opts.activate
         })
       })
 
-      if (opts.activate !== false) {
+      if (!pairedCreate && opts.activate !== false) {
         this.notifier?.focusTerminal(reply.tabId, worktreeId, null)
       }
       // Why: register the wait before the renderer's PTY spawn arrives so that
@@ -186,6 +192,7 @@ export class OrcaRuntimeWithRunCreateMobileSessionTerminal extends OrcaRuntimeWi
           opts.activate !== false,
           opts.afterTabId,
           {
+            workOrigin,
             command: startupCommand.command,
             cwd,
             env: startupCommand.env,

--- a/src/main/runtime/orca-runtime-split-pty-backed-terminal.ts
+++ b/src/main/runtime/orca-runtime-split-pty-backed-terminal.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
+import type { WorkOrigin } from '../../shared/work-origin'
 import { OrcaRuntimeWithSplitTerminal } from './orca-runtime-split-terminal'
 import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
 import type { TerminalPaneSplitSource } from '../../shared/feature-education-telemetry'
@@ -11,6 +12,7 @@ export class OrcaRuntimeWithSplitPtyBackedTerminal extends OrcaRuntimeWithSplitT
   protected async splitPtyBackedTerminal(
     pty: RuntimePtyWorktreeRecord,
     opts: {
+      workOrigin?: WorkOrigin
       direction?: 'horizontal' | 'vertical'
       command?: string
       env?: Record<string, string>
@@ -54,6 +56,7 @@ export class OrcaRuntimeWithSplitPtyBackedTerminal extends OrcaRuntimeWithSplitT
       rows: 40,
       cwd: workspace.path,
       command: opts.command,
+      workOrigin: opts.workOrigin,
       commandDelivery: 'provider',
       env: this.buildTerminalWorkspaceEnv(workspace, opts.env ?? {}, paneKey, parentTabId),
       envToDelete: opts.envToDelete,
@@ -89,6 +92,7 @@ export class OrcaRuntimeWithSplitPtyBackedTerminal extends OrcaRuntimeWithSplitT
     this.registerPty(result.id, workspace.id, workspace.connectionId)
     const createdPty = this.getOrCreatePtyWorktreeRecord(result.id)
     if (createdPty) {
+      createdPty.workOrigin = opts.workOrigin === undefined ? { kind: 'host' } : opts.workOrigin
       createdPty.tabId = parentTabId
       createdPty.paneKey = paneKey
       createdPty.runtimeSessionOwned = pty.runtimeSessionOwned

--- a/src/main/runtime/orca-runtime-split-terminal.ts
+++ b/src/main/runtime/orca-runtime-split-terminal.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
+import type { WorkOrigin } from '../../shared/work-origin'
 import { OrcaRuntimeWithStopExplicitlyClosedTabPtys } from './orca-runtime-stop-explicitly-closed-tab-ptys'
 import type { TerminalPaneSplitSource } from '../../shared/feature-education-telemetry'
 import type { RuntimeTerminalSplit } from '../../shared/runtime-types'
@@ -8,6 +9,7 @@ export class OrcaRuntimeWithSplitTerminal extends OrcaRuntimeWithStopExplicitlyC
   async splitTerminal(
     handle: string,
     opts: {
+      workOrigin?: WorkOrigin
       direction?: 'horizontal' | 'vertical'
       command?: string
       env?: Record<string, string>
@@ -32,6 +34,7 @@ export class OrcaRuntimeWithSplitTerminal extends OrcaRuntimeWithStopExplicitlyC
     this.notifier?.splitTerminal(leaf.tabId, leaf.paneRuntimeId, {
       direction,
       command: opts.command,
+      workOrigin: opts.workOrigin,
       worktreeId: leaf.worktreeId,
       sourceLeafId: leaf.leafId,
       telemetrySource: opts.telemetrySource,

--- a/src/main/runtime/push/push-dispatcher.test.ts
+++ b/src/main/runtime/push/push-dispatcher.test.ts
@@ -10,6 +10,22 @@ import {
 } from './push-dispatcher.test-fixture'
 
 describe('PushDispatcher', () => {
+  it.each([
+    [{ kind: 'paired-device', deviceId: 'a' }, ['reg-a']],
+    [null, []],
+    [{ kind: 'paired-device', deviceId: 'revoked' }, []]
+  ] as const)('routes attributed work only to its device: %j', async (workOrigin, recipients) => {
+    const harness = createHarness({
+      devices: [
+        { deviceId: 'a', pushRegistration: registration({ registrationId: 'reg-a' }) },
+        { deviceId: 'b', pushRegistration: registration({ registrationId: 'reg-b' }) }
+      ]
+    })
+    harness.dispatcher.enqueue(notification({ workOrigin }))
+    await flush()
+    expect(harness.sends.flatMap((send) => send.registrationIds)).toEqual(recipients)
+  })
+
   it('batches every matching registration into one send', async () => {
     const harness = createHarness({
       devices: [

--- a/src/main/runtime/push/push-dispatcher.ts
+++ b/src/main/runtime/push/push-dispatcher.ts
@@ -1,3 +1,4 @@
+import { workOriginAllowsDevice } from '../../../shared/work-origin'
 import { reserveNotificationCooldown } from '../../../shared/notification-burst-cooldown'
 // Why: the out-of-band leg of the mobile notification fan-out. Every event that
 // already went to connected sockets is offered to the push gateway so a phone
@@ -157,7 +158,8 @@ export class PushDispatcher {
       if (
         !registration ||
         registration.expiresAt <= Date.now() ||
-        !allowsPushDelivery(registration, event)
+        !allowsPushDelivery(registration, event) ||
+        !workOriginAllowsDevice(event.workOrigin, device.deviceId)
       ) {
         return []
       }

--- a/src/main/runtime/rpc/methods/client-events.ts
+++ b/src/main/runtime/rpc/methods/client-events.ts
@@ -9,12 +9,15 @@ export const CLIENT_EVENT_METHODS = [
   defineStreamingMethod({
     name: 'runtime.clientEvents.subscribe',
     params: null,
-    handler: async (_params, { runtime, connectionId, clientKind }, emit) => {
+    handler: async (_params, { runtime, connectionId, clientKind, pairedDeviceId }, emit) => {
       await new Promise<void>((resolve) => {
         // Why: mobile discards terminalSideEffects; excluding it stops the
         // per-OSC batch frames from crossing the relay.
         const unsubscribe = runtime.onClientEvent(
           (event) => {
+            if (event.type === 'activateWorktree' && event.recipientDeviceId !== pairedDeviceId) {
+              return
+            }
             emit(event)
           },
           { consumesTerminalSideEffects: clientKind !== 'mobile' }

--- a/src/main/runtime/rpc/methods/notification-reconnect-cooldown.test.ts
+++ b/src/main/runtime/rpc/methods/notification-reconnect-cooldown.test.ts
@@ -63,3 +63,63 @@ it.each([0, 255])(
     }
   }
 )
+
+it('uses the same recipient for live delivery and missed-event replay', async () => {
+  const controller = new RuntimeMobileNotificationController()
+  const cleanups: (() => void)[] = []
+  const runtime = {
+    onNotificationDispatched: controller.onDispatched.bind(controller),
+    getMobileNotificationEpoch: controller.getEpoch.bind(controller),
+    getMissedNotificationsSince: controller.getMissedSince.bind(controller),
+    registerSubscriptionCleanup: (_id: string, cleanup: () => void) => cleanups.push(cleanup)
+  }
+  const subscribe = NOTIFICATION_METHODS.find(
+    (m) => m.name === 'notifications.subscribe'
+  ) as RpcStreamingMethod
+  const replay = NOTIFICATION_METHODS.find(
+    (m) => m.name === 'notifications.getMissedSince'
+  ) as RpcMethod
+  const a: unknown[] = [],
+    b: unknown[] = []
+  const contexts = ['a', 'b'].map(
+    (pairedDeviceId) => ({ runtime, pairedDeviceId }) as unknown as RpcContext
+  )
+  const pending = [
+    subscribe.handler(undefined, contexts[0]!, (event) => a.push(event)),
+    subscribe.handler(undefined, contexts[1]!, (event) => b.push(event))
+  ]
+  try {
+    for (const deviceId of ['a', 'b']) {
+      controller.dispatch({
+        type: 'notification',
+        source: 'agent-task-complete',
+        title: deviceId,
+        body: '',
+        worktreeId: 'shared-workspace',
+        emittedAt: 10000,
+        workOrigin: { kind: 'paired-device', deviceId }
+      })
+    }
+    controller.dispatch({
+      type: 'notification',
+      source: 'agent-task-complete',
+      title: 'unknown',
+      body: '',
+      workOrigin: null
+    })
+    expect(a).toHaveLength(2)
+    expect(b).toHaveLength(2)
+    expect(a[1]).toMatchObject({ title: 'a' })
+    expect(b[1]).toMatchObject({ title: 'b' })
+    for (const [index, ctx] of contexts.entries()) {
+      const result = await replay.handler(
+        { lastSeenSeq: 0, epoch: controller.getEpoch(), includeDesktopSuppressed: true },
+        ctx
+      )
+      expect(result).toMatchObject({ notifications: [{ title: index === 0 ? 'a' : 'b' }] })
+    }
+  } finally {
+    cleanups.forEach((stop) => stop())
+    await Promise.all(pending)
+  }
+})

--- a/src/main/runtime/rpc/methods/notifications.ts
+++ b/src/main/runtime/rpc/methods/notifications.ts
@@ -1,3 +1,4 @@
+import { workOriginAllowsDevice } from '../../../../shared/work-origin'
 import { createNotificationStreamFilter } from './notification-stream-policy'
 import { defineStreamingMethod, defineMethod } from '../core'
 import {
@@ -17,11 +18,14 @@ export const NOTIFICATION_METHODS = [
   defineStreamingMethod({
     name: 'notifications.subscribe',
     params: NotificationsSubscribeParams,
-    handler: async (params, { runtime, connectionId }, emit) => {
+    handler: async (params, { runtime, connectionId, pairedDeviceId }, emit) => {
       const shouldEmit = createNotificationStreamFilter(params?.includeDesktopSuppressed)
       await new Promise<void>((resolve) => {
         const unsubscribe = runtime.onNotificationDispatched((event) => {
-          if (shouldEmit(event)) {
+          if (
+            shouldEmit(event) &&
+            (event.type === 'dismiss' || workOriginAllowsDevice(event.workOrigin, pairedDeviceId))
+          ) {
             emit(event)
           }
         })
@@ -60,12 +64,15 @@ export const NOTIFICATION_METHODS = [
     // Why: returns only notifications with seq > lastSeenSeq. The runtime owns
     // the monotonic seq, so this is the single source of truth for what the
     // client missed while its socket was reaped.
-    handler: async (params, { runtime }) => {
+    handler: async (params, { runtime, pairedDeviceId }) => {
       const missed = runtime.getMissedNotificationsSince(params.lastSeenSeq, params.epoch)
       return {
-        notifications: missed.filter(
-          createNotificationStreamFilter(params.includeDesktopSuppressed)
-        ),
+        notifications: missed
+          .filter(createNotificationStreamFilter(params.includeDesktopSuppressed))
+          .filter(
+            (event) =>
+              event.type === 'dismiss' || workOriginAllowsDevice(event.workOrigin, pairedDeviceId)
+          ),
         epoch: runtime.getMobileNotificationEpoch(),
         ...(params.deliveredPushes
           ? { dismissedPushes: runtime.reconcileDismissedPushes(params.deliveredPushes) }

--- a/src/main/runtime/rpc/methods/orchestration-structured-worker-session.ts
+++ b/src/main/runtime/rpc/methods/orchestration-structured-worker-session.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../../../shared/work-origin'
 /**
  * Starting, holding and retiring a worker that IS a structured agent session.
  *
@@ -77,6 +78,7 @@ export function releaseStructuredWorkerSession(
 
 export async function createStructuredWorkerSession(args: {
   runtime: OrcaRuntimeService
+  workOrigin?: WorkOrigin
   worktreeId: string
   agent: 'claude' | 'codex'
   dispatchId: string
@@ -106,6 +108,7 @@ export async function createStructuredWorkerSession(args: {
   try {
     created = await createStructuredAgentSessionForWorktree({
       runtime: args.runtime,
+      workOrigin: args.workOrigin,
       ensureHost: async () => {
         await args.runtime.ensureStructuredAgentSessionHost()
         return requireInstalledHost()

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-start-agent-placement.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-start-agent-placement.ts
@@ -157,6 +157,7 @@ async function createWorkerAgentSurface(
   if (mode.mode === 'structured') {
     const structuredSession = await createStructuredWorkerSessionForWorktree({
       runtime: args.runtime,
+      workOrigin: args.runtime.getTerminalWorkOrigin(args.params.from) ?? null,
       worktreeId,
       agent: args.agent as TuiAgent,
       dispatchId: args.dispatchId,
@@ -167,6 +168,7 @@ async function createWorkerAgentSurface(
   }
   const terminal = await createExistingWorktreeWorkerTerminal({
     runtime: args.runtime,
+    workOrigin: args.runtime.getTerminalWorkOrigin(args.params.from) ?? null,
     worktreeId,
     agent: args.agent as TuiAgent,
     ...(args.launchPreferences ? { launchPreferences: args.launchPreferences } : {}),

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-topology.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../../../../../shared/work-origin'
 import type { AgentLaunchPreferences } from '../../../../../../shared/agent-session-host-authority'
 import { narrowStructuredLaunchSeedOptions } from '../../../../../../shared/native-chat-session-option-defaults'
 import type { TuiAgent } from '../../../../../../shared/tui-agent'
@@ -58,6 +59,7 @@ export function requireWorkerAuthority(runtime: OrcaRuntimeService, terminalHand
 
 export async function createExistingWorktreeWorkerTerminal(args: {
   runtime: OrcaRuntimeService
+  workOrigin?: WorkOrigin
   worktreeId: string
   agent: TuiAgent
   launchPreferences?: AgentLaunchPreferences
@@ -65,6 +67,7 @@ export async function createExistingWorktreeWorkerTerminal(args: {
   effects: WorkerEffect[]
 }): Promise<{ handle: string; warning?: string }> {
   const terminal = await args.runtime.createTerminal(`id:${args.worktreeId}`, {
+    workOrigin: args.workOrigin,
     // Why: the agent id is not a shell command — `cursor` resolves to the Cursor
     // desktop app while its CLI is `cursor-agent`. Let the runtime build the
     // configured launcher instead of executing the raw id.
@@ -94,6 +97,7 @@ export async function createExistingWorktreeWorkerTerminal(args: {
  */
 export async function createStructuredWorkerSessionForWorktree(args: {
   runtime: OrcaRuntimeService
+  workOrigin?: WorkOrigin
   worktreeId: string
   agent: TuiAgent
   dispatchId: string
@@ -110,6 +114,7 @@ export async function createStructuredWorkerSessionForWorktree(args: {
   const options = narrowStructuredLaunchSeedOptions(args.launchPreferences)
   const created = await createStructuredWorkerSession({
     runtime: args.runtime,
+    workOrigin: args.workOrigin,
     worktreeId: args.worktreeId,
     agent: args.agent,
     dispatchId: args.dispatchId,
@@ -150,6 +155,7 @@ export function applyWaitForSetupOutcome(
 
 export function monitorWorkerSetup(args: {
   runtime: OrcaRuntimeService
+  workOrigin?: WorkOrigin
   db: OrchestrationDb
   runId: string
   dispatchId: string

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-worktree-creation.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-worktree-creation.ts
@@ -46,6 +46,7 @@ export async function createWorkerWorktree(args: {
   const setupDecision = params.setup ?? 'run'
   db.recordWorkerStage({ dispatchId, stage: 'worktree_creating', effects })
   const created = await runtime.createManagedWorktree({
+    workOrigin: runtime.getTerminalWorkOrigin(params.from) ?? null,
     repoSelector: params.repo ?? coordinatorWorktree.repoId,
     name: params.name as string,
     baseBranch: params.baseBranch,

--- a/src/main/runtime/rpc/methods/structured-agent-session-create.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-create.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../../../shared/work-origin'
 /**
  * Creating a structured session for a worktree: resolve the create intent, attach it under the
  * host-computed fingerprint, then publish its tab.
@@ -42,6 +43,7 @@ export type PreparedStructuredAgentSessionCreate = {
  *  `resolveUncommittedStructuredCreate` so a failure reaches the client as a refusal. */
 export async function prepareStructuredAgentSessionCreateForWorktree(args: {
   runtime: OrcaRuntimeService
+  workOrigin?: WorkOrigin
   /** Installs the host lazily; called at the same point the RPC handler always installed it. */
   ensureHost: () => Promise<StructuredAgentSessionHost>
   envelope: AgentSessionMutationEnvelope
@@ -74,6 +76,7 @@ export async function prepareStructuredAgentSessionCreateForWorktree(args: {
     host,
     attachParams: {
       ...resolvedAttach,
+      workOrigin: args.workOrigin === undefined ? { kind: 'host' } : args.workOrigin,
       // After the fingerprint, deliberately: `attachFingerprintFields` excludes options because
       // they are the session's initial state, not its identity, so a retry that re-resolves them
       // must replay rather than conflict.
@@ -92,6 +95,7 @@ export async function prepareStructuredAgentSessionCreateForWorktree(args: {
 /** The commit half. Past `attach`, a failure no longer proves the session does not exist. */
 export async function commitStructuredAgentSessionCreate(args: {
   runtime: OrcaRuntimeService
+  workOrigin?: WorkOrigin
   caller: StructuredAgentSessionCaller
   prepared: PreparedStructuredAgentSessionCreate
   activate: boolean
@@ -123,6 +127,7 @@ export async function commitStructuredAgentSessionCreate(args: {
 
 export async function createStructuredAgentSessionForWorktree(args: {
   runtime: OrcaRuntimeService
+  workOrigin?: WorkOrigin
   ensureHost: () => Promise<StructuredAgentSessionHost>
   caller: StructuredAgentSessionCaller
   envelope: AgentSessionMutationEnvelope

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -1,3 +1,4 @@
+import { resolveRpcWorkOrigin } from '../work-origin-context'
 // `agentSession.*` — the structured session RPC surface.
 //
 // Every method here is gated on the client advertising
@@ -162,6 +163,7 @@ export const STRUCTURED_AGENT_SESSION_METHODS = [
           }
           return prepareStructuredAgentSessionCreateForWorktree({
             runtime: ctx.runtime,
+            workOrigin: resolveRpcWorkOrigin(ctx),
             ensureHost: async () => {
               await ensureHostInstalled(ctx)
               return requireHost(ctx)
@@ -174,7 +176,11 @@ export const STRUCTURED_AGENT_SESSION_METHODS = [
           })
         }
         const { host, attachParams } = await resolveClientSuppliedAttach(params, ctx)
-        return { host, attachParams, tab: null }
+        return {
+          host,
+          attachParams: { ...attachParams, workOrigin: resolveRpcWorkOrigin(ctx) },
+          tab: null
+        }
       })
       if ('refusal' in prepared) {
         return { ok: false, refusal: prepared.refusal }

--- a/src/main/runtime/rpc/methods/terminal/terminal-lifecycle-methods.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-lifecycle-methods.ts
@@ -1,3 +1,4 @@
+import { resolveRpcWorkOrigin } from '../../work-origin-context'
 import { defineMethod } from '../../core'
 import {
   navigationTargetsHost,
@@ -52,6 +53,7 @@ export const TERMINAL_LIFECYCLE_METHODS = [
           params.reconcileExisting === true,
           (canonicalWorktreeSelector, preAllocatedHandle) =>
             runtime.createTerminal(canonicalWorktreeSelector, {
+              workOrigin: resolveRpcWorkOrigin({ runtime, pairedDeviceId, clientKind }, params),
               command: params.command,
               startupCommandDelivery: params.startupCommandDelivery,
               env: params.env,
@@ -81,8 +83,10 @@ export const TERMINAL_LIFECYCLE_METHODS = [
   defineMethod({
     name: 'terminal.split',
     params: TerminalSplit,
-    handler: async (params, { runtime }) => ({
-      split: await runtime.splitTerminal(params.terminal, {
+    handler: async (params, context) => ({
+      split: await context.runtime.splitTerminal(params.terminal, {
+        workOrigin: resolveRpcWorkOrigin(context, params),
+        ...(context.pairedDeviceId ? { surfaceOwner: false, activate: false } : {}),
         direction: params.direction,
         command: params.command,
         env: params.env,

--- a/src/main/runtime/rpc/methods/worktree-create-args.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-args.ts
@@ -7,7 +7,7 @@ type WorktreeCreateParams = z.infer<typeof WorktreeCreate>
 type ManagedWorktreeCreateArgs = Parameters<OrcaRuntimeService['createManagedWorktree']>[0]
 type CreateProvenance = Pick<
   ManagedWorktreeCreateArgs,
-  'automationProvenance' | 'cliProvenance' | 'creatorProvenance'
+  'automationProvenance' | 'cliProvenance' | 'creatorProvenance' | 'workOrigin'
 >
 
 /** Wire params → runtime create args. Kept out of the method table so the mapping can grow with
@@ -47,19 +47,10 @@ export function buildManagedWorktreeCreateArgs(
     pushTarget: params.pushTarget,
     runHooks: params.runHooks === true,
     activate: params.activate === true,
-    // Why: create-activation is the caller's own view intent; without this a paired
-    // client's create dragged every other connected client and the host with it.
-    // Why 'runtime' only: a phone has no terminal-provisioning renderer, so when it
-    // creates without a startup command the host renderer is what runs the repo's
-    // setup/default tabs off this activation. Scoping mobile would drop that work.
-    // Why the CLI is excluded by payload and not by version: the CLI also pairs as a
-    // 'runtime' device but has no viewer of its own, so scoping it makes --activate
-    // reveal nothing. Current CLIs say so explicitly with `navigation`, but an older
-    // CLI against an updated host cannot; `cliProvenanceRequest` is the marker every
-    // CLI has always sent, and no renderer or phone sends it.
+    // CLI activation inherits its viewer; paired UI navigation stays local.
     navigation: resolveRuntimeNavigationTarget({
       ...(params.navigation ? { navigation: params.navigation } : {}),
-      ...(origin.clientKind === 'runtime' && params.cliProvenanceRequest === undefined
+      ...(origin.clientKind && params.cliProvenanceRequest === undefined
         ? { clientKind: origin.clientKind }
         : {})
     }),

--- a/src/main/runtime/rpc/methods/worktree-create-navigation.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-navigation.test.ts
@@ -24,9 +24,7 @@ const passthroughDedupe = <T>(_repo: string, _id: string | undefined, run: () =>
 describe('worktree.create navigation authority', () => {
   it.each([
     ['runtime', 'caller'],
-    // Why: no phone renderer provisions the host's setup/default tabs off the activation,
-    // so mobile creates keep the all-surface reveal until that work moves to the runtime.
-    ['mobile', 'all']
+    ['mobile', 'caller']
   ] as const)(
     'resolves create activation from the paired %s client kind',
     async (clientKind, expected) => {
@@ -50,10 +48,7 @@ describe('worktree.create navigation authority', () => {
     }
   )
 
-  it('keeps an older CLI reveal working against an updated host', async () => {
-    // Why: an old CLI cannot send `navigation`, but it pairs as a runtime device. Without the
-    // cliProvenanceRequest marker it would resolve to 'caller' and `--activate` would reveal
-    // nothing anywhere — strictly worse than the pre-fix behavior for that version skew.
+  it('preserves an older CLI request without guessing a missing origin', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       dedupeWorktreeCreate: passthroughDedupe,
@@ -74,7 +69,7 @@ describe('worktree.create navigation authority', () => {
     )
 
     expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({ navigation: 'all' })
+      expect.objectContaining({ navigation: 'all', workOrigin: null })
     )
   })
 
@@ -98,7 +93,7 @@ describe('worktree.create navigation authority', () => {
     )
   })
 
-  it('honors an explicit follow navigation on create', async () => {
+  it('keeps explicit follow navigation local to its caller', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       dedupeWorktreeCreate: passthroughDedupe,
@@ -119,11 +114,11 @@ describe('worktree.create navigation authority', () => {
     )
 
     expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({ navigation: 'clients' })
+      expect.objectContaining({ navigation: 'caller' })
     )
   })
 
-  it('keeps an explicit all-surface reveal from a paired caller', async () => {
+  it('keeps explicit all-surface navigation local to its caller', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       dedupeWorktreeCreate: passthroughDedupe,
@@ -144,7 +139,7 @@ describe('worktree.create navigation authority', () => {
     )
 
     expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({ navigation: 'all' })
+      expect.objectContaining({ navigation: 'caller' })
     )
   })
 })

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -1,3 +1,4 @@
+import { resolveRpcWorkOrigin } from '../work-origin-context'
 import {
   finishAutomationWorkspaceProvenanceRequest,
   releaseAutomationWorkspaceProvenanceRequest,
@@ -95,6 +96,7 @@ export const WORKTREE_METHODS = [
             buildManagedWorktreeCreateArgs(
               params,
               {
+                workOrigin: resolveRpcWorkOrigin(context, params),
                 automationProvenance,
                 cliProvenance: buildCliWorkspaceProvenance(params.cliProvenanceRequest, {
                   startupAgent: params.startupAgent ?? params.createdWithAgent,

--- a/src/main/runtime/rpc/work-origin-context.test.ts
+++ b/src/main/runtime/rpc/work-origin-context.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { resolveRpcWorkOrigin } from './work-origin-context'
+import { StructuredAgentSessionHost } from '../../native-chat/agent-session-wire/structured-agent-session-host'
+import { setStructuredAgentSessionHost } from '../../native-chat/agent-session-wire/structured-agent-session-registry'
+import { TERMINAL_METHODS } from './methods/terminal'
+import { RpcDispatcher } from './dispatcher'
+import type { OrcaRuntimeService } from '../orca-runtime'
+
+const origin = { kind: 'paired-device', deviceId: 'desktop-a' } as const
+
+afterEach(() => setStructuredAgentSessionHost(null))
+
+it('inherits a parent run instead of attributing its CLI connection', () => {
+  const runtime = { getTerminalWorkOrigin: vi.fn(() => origin) } as unknown as OrcaRuntimeService
+  const context = { runtime, pairedDeviceId: 'cli-device', clientKind: 'runtime' as const }
+  expect(
+    resolveRpcWorkOrigin(context, { callerTerminalHandle: 'parent', cliProvenanceRequest: {} })
+  ).toEqual(origin)
+  expect(resolveRpcWorkOrigin(context)).toEqual({ kind: 'paired-device', deviceId: 'cli-device' })
+  expect(resolveRpcWorkOrigin(context, { cliProvenanceRequest: {} })).toBeNull()
+})
+
+it('validates native child origin against the live lease for terminal splits', async () => {
+  const host = Object.create(StructuredAgentSessionHost.prototype) as StructuredAgentSessionHost
+  Object.assign(host, {
+    deps: {
+      store: {
+        getRecord: (id: string) =>
+          id === 'session-a'
+            ? {
+                workOrigin: origin,
+                lease: { claimStatus: 'live', ownerProcess: { spawnToken: 'current-token' } }
+              }
+            : null
+      }
+    }
+  })
+  setStructuredAgentSessionHost(host)
+  const splitTerminal = vi.fn(async () => ({ handle: 'child' }))
+  const runtime = { splitTerminal, getRuntimeId: () => 'host' } as unknown as OrcaRuntimeService
+  const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+  for (const spawnToken of ['current-token', 'stale-token']) {
+    await dispatcher.dispatch({
+      id: spawnToken,
+      authToken: 'token',
+      method: 'terminal.split',
+      params: {
+        terminal: 'target-pane',
+        cliProvenanceRequest: {},
+        callerOriginSession: { sessionId: 'session-a', spawnToken }
+      }
+    })
+    expect(splitTerminal).toHaveBeenLastCalledWith(
+      'target-pane',
+      expect.objectContaining({ workOrigin: spawnToken === 'current-token' ? origin : null })
+    )
+  }
+})

--- a/src/main/runtime/rpc/work-origin-context.ts
+++ b/src/main/runtime/rpc/work-origin-context.ts
@@ -1,0 +1,27 @@
+import { getStructuredAgentSessionHost } from '../../native-chat/agent-session-wire/structured-agent-session-registry'
+import type { WorkOrigin } from '../../../shared/work-origin'
+import type { RpcContext } from './core'
+
+export function resolveRpcWorkOrigin(
+  context: Pick<RpcContext, 'runtime' | 'pairedDeviceId' | 'clientKind'>,
+  caller: {
+    callerOriginSession?: { sessionId: string; spawnToken: string }
+    callerTerminalHandle?: string
+    cliProvenanceRequest?: unknown
+  } = {}
+): WorkOrigin {
+  if (caller.callerOriginSession) {
+    const { sessionId, spawnToken } = caller.callerOriginSession
+    return getStructuredAgentSessionHost()?.resolveChildWorkOrigin(sessionId, spawnToken) ?? null
+  }
+  if (caller.callerTerminalHandle) {
+    return context.runtime.getTerminalWorkOrigin(caller.callerTerminalHandle) ?? null
+  }
+  if (caller.cliProvenanceRequest !== undefined) {
+    return null
+  }
+  if (context.pairedDeviceId) {
+    return { kind: 'paired-device', deviceId: context.pairedDeviceId }
+  }
+  return context.clientKind ? null : { kind: 'host' }
+}

--- a/src/main/runtime/runtime-folder-worktree-create.ts
+++ b/src/main/runtime/runtime-folder-worktree-create.ts
@@ -124,7 +124,9 @@ export async function createRuntimeFolderWorktree(args: {
     path: worktree.path,
     branch: worktree.branch
   })
-  const shouldActivate = request.activate === true || request.runHooks === true
+  const wantsReveal = request.activate === true
+  const addressed = request.workOrigin !== undefined && request.workOrigin?.kind !== 'host'
+  const shouldActivate = wantsReveal && !addressed
   let warning: string | undefined
   let didSpawnStartup = false
   let startupTerminal: CreateWorktreeResult['startupTerminal']
@@ -183,6 +185,9 @@ export async function createRuntimeFolderWorktree(args: {
         : initialWarning
       console.warn(`[worktree-create] ${warning}`)
     }
+  }
+  if (wantsReveal && addressed) {
+    deps.activate(repo.id, worktree.id)
   }
   return {
     worktree: {

--- a/src/main/runtime/runtime-local-worktree-terminal-startup.ts
+++ b/src/main/runtime/runtime-local-worktree-terminal-startup.ts
@@ -28,7 +28,7 @@ type Ports = {
   sendFollowup: (handle: string, followup: WorktreeStartupFollowup) => void
   provision: (
     options: WorktreeTerminalProvisioningArgs
-  ) => Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }>
+  ) => Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null; warning?: string }>
   activate: (
     repoId: string,
     worktreeId: string,
@@ -64,7 +64,9 @@ export async function startRuntimeLocalWorktreeTerminals(args: {
   ports: Ports
 }): Promise<RuntimeLocalWorktreeTerminalStartupResult> {
   const { request, repo, worktree, setup, defaultTabs, startup, ports } = args
-  const shouldActivate = request.activate === true || request.runHooks === true
+  const wantsReveal = request.activate === true
+  const addressed = request.workOrigin !== undefined && request.workOrigin?.kind !== 'host'
+  const shouldActivate = wantsReveal && !addressed
   let warning = args.warning
   let didSpawnStartup = false
   let didSpawnSetup = false
@@ -130,6 +132,9 @@ export async function startRuntimeLocalWorktreeTerminals(args: {
       const provisioned = await ports.provision(
         provisionArgs(args, startupTerminalHandle, didSpawnStartup, wrappedSetupCommand)
       )
+      if (provisioned.warning) {
+        warning = [warning, provisioned.warning].filter(Boolean).join(' ')
+      }
       didSpawnSetup = provisioned.setupSpawned
       setupTerminalHandle = provisioned.setupTerminalHandle
     }
@@ -153,8 +158,11 @@ export async function startRuntimeLocalWorktreeTerminals(args: {
       ...provisionArgs(args, startupTerminalHandle, didSpawnStartup, wrappedSetupCommand),
       surfaceOwner: false
     })
-    if (request.awaitTerminalProvisioning) {
+    if (request.awaitTerminalProvisioning || addressed) {
       const provisioned = await provisioning
+      if (provisioned.warning) {
+        warning = [warning, provisioned.warning].filter(Boolean).join(' ')
+      }
       didSpawnSetup = provisioned.setupSpawned
       setupTerminalHandle = provisioned.setupTerminalHandle
     } else {
@@ -170,14 +178,18 @@ export async function startRuntimeLocalWorktreeTerminals(args: {
       warning = appendFailure(warning, worktree.path, 'initial', error)
     }
   }
-  const returnedSetup = didSpawnSetup
-    ? undefined
-    : setup
-      ? {
-          ...setup,
-          ...(didSpawnStartup && wrappedSetupCommand ? { command: wrappedSetupCommand } : {})
-        }
-      : undefined
+  if (wantsReveal && addressed) {
+    ports.activate(repo.id, worktree.id, undefined, undefined, undefined)
+  }
+  const returnedSetup =
+    addressed || didSpawnSetup
+      ? undefined
+      : setup
+        ? {
+            ...setup,
+            ...(didSpawnStartup && wrappedSetupCommand ? { command: wrappedSetupCommand } : {})
+          }
+        : undefined
   return {
     ...(warning ? { warning } : {}),
     ...(returnedSetup ? { returnedSetup } : {}),

--- a/src/main/runtime/runtime-managed-worktree-create-types.ts
+++ b/src/main/runtime/runtime-managed-worktree-create-types.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { AgentLaunchPreferences } from '../../shared/agent-session-host-authority'
 import type { CreateWorktreeArgs } from '../../shared/worktree/create-types'
 import type {
@@ -19,6 +20,7 @@ export type RuntimeManagedWorktreeCreateArgs = {
   name: string
   nameWasGenerated?: boolean
   navigation?: RuntimeNavigationTarget
+  workOrigin?: WorkOrigin
   baseBranch?: string
   compareBaseRef?: string
   branchNameOverride?: string

--- a/src/main/runtime/runtime-mobile-notification-controller.ts
+++ b/src/main/runtime/runtime-mobile-notification-controller.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import { reserveNotificationCooldown } from '../../shared/notification-burst-cooldown'
 import type { AgentStatusState } from '../../shared/agent-status-types'
 import type {
@@ -15,6 +16,7 @@ import {
 
 export type MobileNotificationDispatchEvent = {
   type: 'notification'
+  workOrigin?: WorkOrigin
   legacySocketAllowed?: boolean
   desktopAllowed?: boolean
   desktopAway?: boolean
@@ -104,7 +106,7 @@ export class RuntimeMobileNotificationController {
         (event.emittedAt === undefined ||
           reserveNotificationCooldown(
             this.legacyCooldown,
-            event.worktreeId ?? 'global',
+            JSON.stringify([event.workOrigin, event.worktreeId ?? 'global']),
             event.emittedAt
           ))
       event = {

--- a/src/main/runtime/runtime-mobile-session-projection-contract.ts
+++ b/src/main/runtime/runtime-mobile-session-projection-contract.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { AgentStatusEntry, AgentStatusIpcPayload } from '../../shared/agent-status-types'
 import type {
   BrowserTabInfo,
@@ -12,6 +13,11 @@ import type { RuntimeAgentRowSnapshot } from './runtime-worktree-agent-rows'
 import type { RuntimeLeafRecord, RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
 
 export type RuntimeMobileSessionProjectionHost = {
+  getWorkOrigin?(
+    worktreeId: string,
+    paneKey: string,
+    pty?: RuntimePtyWorktreeRecord | null
+  ): WorkOrigin | undefined
   tabs: ReadonlyMap<string, RuntimeSyncedTab>
   leaves: ReadonlyMap<string, RuntimeLeafRecord>
   ptysById: ReadonlyMap<string, RuntimePtyWorktreeRecord>

--- a/src/main/runtime/runtime-mobile-session-projection.ts
+++ b/src/main/runtime/runtime-mobile-session-projection.ts
@@ -285,6 +285,7 @@ export function projectRuntimeMobileSessionTabs(
       : {}
     tabs.push({
       type: 'terminal',
+      workOrigin: host.getWorkOrigin?.(snapshot.worktree, paneKey, livePty),
       id: tab.id,
       parentTabId: tab.parentTabId,
       leafId: tab.leafId,

--- a/src/main/runtime/runtime-pty-controller-contract.ts
+++ b/src/main/runtime/runtime-pty-controller-contract.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type {
   AgentSessionClaimedSpawnResult,
   AgentSessionExecutionClaim,
@@ -46,6 +47,7 @@ export type RuntimePtyController = {
     cwd?: string
     command?: string
     launchAgent?: TuiAgent
+    workOrigin?: WorkOrigin
     commandDelivery?: 'renderer' | 'provider'
     startupCommandDelivery?: WorktreeStartupLaunch['startupCommandDelivery']
     env?: Record<string, string>

--- a/src/main/runtime/runtime-remote-managed-worktree-create.test.ts
+++ b/src/main/runtime/runtime-remote-managed-worktree-create.test.ts
@@ -1,0 +1,51 @@
+import { expect, it, vi } from 'vitest'
+import { createRuntimeRemoteManagedWorktree } from './runtime-remote-managed-worktree-create'
+
+vi.mock('./runtime-remote-worktree-create-request', () => ({
+  requestRuntimeRemoteWorktree: vi.fn(async () => ({
+    worktree: { id: 'repo::remote', path: '/srv/remote' },
+    setup: { runnerScriptPath: '/srv/setup.sh', envVars: {} },
+    defaultTabs: { tabs: [{ title: 'Shell' }], runCommands: false }
+  }))
+}))
+
+it('provisions paired SSH creates before addressed reveal without returning duplicate launch instructions', async () => {
+  let finish!: (value: { setupSpawned: boolean; setupTerminalHandle: string }) => void
+  const provision = vi.fn(
+    () =>
+      new Promise<{ setupSpawned: boolean; setupTerminalHandle: string }>((resolve) => {
+        finish = resolve
+      })
+  )
+  const activate = vi.fn()
+  const pending = createRuntimeRemoteManagedWorktree(
+    { id: 'repo', connectionId: 'ssh-a' } as never,
+    {
+      name: 'remote',
+      activate: true,
+      navigation: 'caller',
+      workOrigin: { kind: 'paired-device', deviceId: 'a' }
+    },
+    {
+      store: {} as never,
+      canSpawn: () => true,
+      provision,
+      activate,
+      createTerminal: vi.fn(),
+      markTrusted: vi.fn(),
+      pasteDraft: vi.fn(),
+      sendFollowup: vi.fn(),
+      invalidateResolvedWorktrees: vi.fn(),
+      invalidateWorktreeScan: vi.fn(),
+      notifyWorktreesChanged: vi.fn()
+    }
+  )
+  await vi.waitFor(() => expect(provision).toHaveBeenCalledOnce())
+  expect(provision).toHaveBeenCalledWith(expect.objectContaining({ surfaceOwner: false }))
+  expect(activate).not.toHaveBeenCalled()
+  finish({ setupSpawned: true, setupTerminalHandle: 'setup' })
+  const result = await pending
+  expect(result.setup).toBeUndefined()
+  expect(result.defaultTabs).toBeUndefined()
+  expect(activate).toHaveBeenCalledWith('repo', 'repo::remote')
+})

--- a/src/main/runtime/runtime-remote-managed-worktree-create.ts
+++ b/src/main/runtime/runtime-remote-managed-worktree-create.ts
@@ -36,7 +36,7 @@ type Dependencies = {
   sendFollowup(handle: string, followup: WorktreeStartupFollowup): void
   provision(
     args: WorktreeTerminalProvisioningArgs
-  ): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }>
+  ): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null; warning?: string }>
   activate(
     repoId: string,
     worktreeId: string,
@@ -72,7 +72,9 @@ export async function createRuntimeRemoteManagedWorktree(
   deps.invalidateWorktreeScan(repo.id)
   deps.notifyWorktreesChanged(repo.id)
 
-  const shouldActivate = args.activate === true || args.runHooks === true
+  const wantsReveal = args.activate === true
+  const addressed = args.workOrigin !== undefined && args.workOrigin?.kind !== 'host'
+  const shouldActivate = wantsReveal && !addressed
   let warning = result.warning
   let didSpawnStartup = false
   // Why: same no-double-spawn contract as the local path — once runtime
@@ -161,6 +163,9 @@ export async function createRuntimeRemoteManagedWorktree(
         // remote Setup tab runs the same script the sequenced agent waits on.
         ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {})
       })
+      if (provisioned.warning) {
+        warning = [warning, provisioned.warning].filter(Boolean).join(' ')
+      }
       didSpawnSetup = provisioned.setupSpawned
       setupTerminalHandle = provisioned.setupTerminalHandle
     }
@@ -212,8 +217,11 @@ export async function createRuntimeRemoteManagedWorktree(
     })
     // Why: runtime owns setup spawning here, so omit setup from the RPC result
     // to keep the headless/mobile caller from launching it a second time.
-    if (args.awaitTerminalProvisioning) {
+    if (args.awaitTerminalProvisioning || addressed) {
       const provisioned = await provisioning
+      if (provisioned.warning) {
+        warning = [warning, provisioned.warning].filter(Boolean).join(' ')
+      }
       didSpawnSetup = provisioned.setupSpawned
       setupTerminalHandle = provisioned.setupTerminalHandle
     } else {
@@ -233,6 +241,9 @@ export async function createRuntimeRemoteManagedWorktree(
     }
   }
 
+  if (wantsReveal && addressed) {
+    deps.activate(repo.id, result.worktree.id)
+  }
   return finishRuntimeRemoteWorktreeCreate({
     result,
     request: args,

--- a/src/main/runtime/runtime-remote-worktree-create-result.ts
+++ b/src/main/runtime/runtime-remote-worktree-create-result.ts
@@ -14,22 +14,28 @@ export function finishRuntimeRemoteWorktreeCreate(args: {
   startupTerminalPaneKey: string | null
   startupTerminalPtyId: string | null
 }): CreateWorktreeResult {
-  const returnedSetup = args.didSpawnSetup
-    ? undefined
-    : args.result.setup
-      ? {
-          ...args.result.setup,
-          ...(args.didSpawnStartup && args.wrappedSetupCommand
-            ? { command: args.wrappedSetupCommand }
-            : {})
-        }
-      : undefined
+  const addressed =
+    args.request.workOrigin !== undefined && args.request.workOrigin?.kind !== 'host'
+  const returnedSetup =
+    addressed || args.didSpawnSetup
+      ? undefined
+      : args.result.setup
+        ? {
+            ...args.result.setup,
+            ...(args.didSpawnStartup && args.wrappedSetupCommand
+              ? { command: args.wrappedSetupCommand }
+              : {})
+          }
+        : undefined
   const resultForRenderer = returnedSetup
     ? { ...args.result, setup: returnedSetup }
     : (() => {
         const { setup: _setup, ...resultWithoutSetup } = args.result
         return resultWithoutSetup
       })()
+  if (addressed) {
+    delete resultForRenderer.defaultTabs
+  }
   const resultWithStartupTerminal =
     args.didSpawnStartup && args.startupTerminalHandle
       ? {

--- a/src/main/runtime/runtime-terminal-contracts.ts
+++ b/src/main/runtime/runtime-terminal-contracts.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { ParsedAgentStatusPayload } from '../../shared/agent-status-types'
 import type {
   AgentLaunchPreferences,
@@ -22,6 +23,7 @@ import type { WorkerTerminalHostScope } from './orchestration/worker-terminal-pr
 
 export type TerminalCreateOptions = {
   command?: string
+  workOrigin?: WorkOrigin
   claudeAgentTeamsSourceCommand?: string
   cwd?: string
   env?: Record<string, string>

--- a/src/main/runtime/runtime-terminal-state-records.ts
+++ b/src/main/runtime/runtime-terminal-state-records.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type { AgentStatus } from '../../shared/agent-detection'
 import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
@@ -57,6 +58,7 @@ export type RuntimePtyWorktreeRecord = RuntimeTerminalTailState & {
   launchToken: string | null
   launchIncarnationId: PtyIncarnationId | null
   launchAgent: TuiAgent | null
+  workOrigin?: WorkOrigin
   agentSessionOwners: AgentSessionOwnerBinding[]
   foregroundAgent: TuiAgent | null
   connected: boolean

--- a/src/main/runtime/runtime-worktree-terminal-provisioning.ts
+++ b/src/main/runtime/runtime-worktree-terminal-provisioning.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import { randomUUID } from 'node:crypto'
 import type { CreateWorktreeResult } from '../../shared/worktree/create-types'
 import type { GlobalSettings } from '../../shared/global-settings-types'
@@ -13,6 +14,7 @@ export type WorktreeProvisionTerminalOptions = {
   direction?: 'horizontal' | 'vertical'
   activate?: boolean
   surfaceOwner?: false
+  workOrigin?: WorkOrigin
 }
 
 export type WorktreeTerminalProvisioningHost = {
@@ -44,6 +46,7 @@ export type WorktreeTerminalProvisioningArgs = {
   // Why: setup and startup must use the same wrapper when startup waits for setup.
   wrappedSetupCommand?: string
   surfaceOwner?: false
+  workOrigin?: WorkOrigin
 }
 
 export async function createWorktreeDefaultTabTerminals(
@@ -51,7 +54,8 @@ export async function createWorktreeDefaultTabTerminals(
   selector: string,
   worktreeId: string,
   defaultTabs: CreateWorktreeResult['defaultTabs'] | undefined,
-  surfacing: { surfaceOwner?: false } = {}
+  surfacing: { surfaceOwner?: false; workOrigin?: WorkOrigin } = {},
+  onFailure?: (message: string) => void
 ): Promise<string[]> {
   if (!defaultTabs || defaultTabs.tabs.length === 0 || !host.canSpawn()) {
     return []
@@ -70,7 +74,9 @@ export async function createWorktreeDefaultTabTerminals(
         await host.setTabColor(worktreeId, terminal.tabId, template.color)
       }
     } catch (error) {
-      console.warn(`[worktree-create] Failed to create default tab for ${worktreeId}:`, error)
+      const message = `Failed to create default tab for ${worktreeId}: ${error instanceof Error ? error.message : String(error)}`
+      onFailure?.(message)
+      console.warn(`[worktree-create] ${message}`)
     }
   }
   return handles
@@ -79,11 +85,15 @@ export async function createWorktreeDefaultTabTerminals(
 export async function provisionWorktreeTerminals(
   host: WorktreeTerminalProvisioningHost,
   args: WorktreeTerminalProvisioningArgs
-): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }> {
+): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null; warning?: string }> {
   if (!host.canSpawn()) {
     return { setupSpawned: false, setupTerminalHandle: null }
   }
-  const surfacing = args.surfaceOwner === false ? { surfaceOwner: false as const } : {}
+  const surfacing = {
+    ...(args.surfaceOwner === false ? { surfaceOwner: false as const } : {}),
+    ...(args.workOrigin !== undefined ? { workOrigin: args.workOrigin } : {})
+  }
+  const warnings: string[] = []
   let setupSpawned = false
   let setupTerminalHandle: string | null = null
   try {
@@ -92,7 +102,8 @@ export async function provisionWorktreeTerminals(
       args.worktreeSelector,
       args.worktreeId,
       args.defaultTabs,
-      surfacing
+      surfacing,
+      (message) => warnings.push(message)
     )
     let primaryHandle = args.primaryTerminalHandle ?? defaultHandles[0] ?? null
     const setupLaunchMode =
@@ -147,9 +158,14 @@ export async function provisionWorktreeTerminals(
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
+    warnings.push(`Failed to create setup/default terminals for ${args.worktreePath}: ${message}`)
     console.warn(
       `[worktree-create] Failed to create setup/default terminals for ${args.worktreePath}: ${message}`
     )
   }
-  return { setupSpawned, setupTerminalHandle }
+  return {
+    setupSpawned,
+    setupTerminalHandle,
+    ...(warnings.length ? { warning: warnings.join(' ') } : {})
+  }
 }

--- a/src/main/runtime/structured-worker-child-identity-env.test.ts
+++ b/src/main/runtime/structured-worker-child-identity-env.test.ts
@@ -67,7 +67,11 @@ describe('structuredWorkerChildIdentityEnv', () => {
     installFakeAppEnvironment({ isPackaged: () => true, getPath: () => USER_DATA })
     const childEnv = { PATH: '/usr/bin' }
     const env = structuredWorkerChildIdentityEnv(SESSION_ID, childEnv)
-    expect(env).toEqual({ PATH: '/usr/bin', ORCA_STRUCTURED_SESSION: '1' })
+    expect(env).toEqual({
+      PATH: '/usr/bin',
+      ORCA_STRUCTURED_SESSION: '1',
+      ORCA_WORK_ORIGIN_SESSION_ID: SESSION_ID
+    })
     expect(env.ORCA_TERMINAL_HANDLE).toBeUndefined()
     expect(env.ORCA_PANE_KEY).toBeUndefined()
     expect(env.ORCA_CLI_COMMAND).toBeUndefined()

--- a/src/main/runtime/structured-worker-child-identity-env.ts
+++ b/src/main/runtime/structured-worker-child-identity-env.ts
@@ -1,38 +1,7 @@
 /**
- * The orchestration identity — and the CLI reachability — a structured worker's own child needs
- * to speak for itself.
- *
- * Without `ORCA_TERMINAL_HANDLE` the worker's Bash tool has nothing to pass as `--from`, and
- * `resolveOrchestrationTerminalHandle` falls back to a cwd lookup that returns whichever leaf in
- * the worktree comes first. Two attacks follow from that: a bare `check` reads and consumes a
- * SIBLING's dispatch mailbox, and a bare `send --type worker_done` can settle a sibling's
- * context-only dispatch, a tier that has no capability token to reject on.
- *
- * `ORCA_CLI_COMMAND: 'orca'` is honest ONLY because of the PATH prepend below. Orca's Linux CLI
- * installs as `orca-ide` so it never claims GNOME Orca's /usr/bin/orca (stablyai/orca#7904), and
- * on packaged macOS/Windows the bundled launcher is reachable only from the app's own resources
- * dir. A PTY worker gets that treatment from `buildPtyHostEnv`; a structured worker has no PTY,
- * so it applies the SAME function here rather than a second, drifting copy of the rule.
- *
- * Deliberately NOT `ORCA_PANE_KEY`. Claude structured sessions run hooks, and a pane key in their
- * environment starts flowing into hook-emitted agent-status payloads and the hook-attestation,
- * agent-row and mobile-projection pipelines, every one of which assumes a pane key names a live
- * PTY leaf. It would also open `selectExactWorkerProviderSession`, which is fail-closed today
- * precisely because a structured session emits no hook agent status. The CLI needs none of it once
- * the handle is present.
- *
- * A session that is not a dispatched worker gets ONE variable, `ORCA_STRUCTURED_SESSION`, and it
- * names nothing: no handle, no pane key, no session id, no token. Its only meaning is "this child
- * is a structured session with no orchestration identity", which is what a verb needs in order to
- * REFUSE rather than guess one. Because it names nothing it cannot be replayed, cannot impersonate,
- * and cannot flow into the hook, agent-row or mobile-projection pipelines the way a pane key would
- * — which is why it is a different decision from withholding `ORCA_PANE_KEY`, not a reversal of it.
- * Without it, `check` fell through to the active-terminal guess and destructively consumed a
- * SIBLING pane's oldest unread batch; `requireUnambiguous` only narrows that, because with exactly
- * one terminal pane in the worktree the guess still resolves — to a sibling.
- *
- * The handle is read from the registry at spawn time, so an in-host recovery respawn re-bakes the
- * SAME handle rather than a stale or fresh one.
+ * Dispatched workers inherit their registered CLI handle. Ordinary chats carry only an origin
+ * session reference, validated with the host-issued spawn token; it grants no orchestration identity.
+ * Never inject ORCA_PANE_KEY: hook/status readers require it to name an actual PTY leaf.
  */
 
 import { getAppEnvironment, hasAppEnvironment } from '../../shared/app-environment'
@@ -46,7 +15,11 @@ export function structuredWorkerChildIdentityEnv(
 ): Record<string, string> {
   const identity = structuredWorkerIdentities.getBySessionId(sessionId)
   if (!identity) {
-    return { ...childEnv, [ORCA_STRUCTURED_SESSION_ENV]: '1' }
+    return {
+      ...childEnv,
+      ORCA_WORK_ORIGIN_SESSION_ID: sessionId,
+      [ORCA_STRUCTURED_SESSION_ENV]: '1'
+    }
   }
   const env: Record<string, string> = {
     ...childEnv,

--- a/src/main/runtime/terminal-create-reveal.ts
+++ b/src/main/runtime/terminal-create-reveal.ts
@@ -1,0 +1,25 @@
+import type { RuntimeNotifier } from './runtime-notifier-contract'
+import type { RuntimeTerminalCreate, RuntimeTerminalPresentation } from '../../shared/runtime-types'
+import { createTerminalRevealWarning } from './orca-runtime-core'
+
+export async function revealCreatedTerminal(
+  notifier: RuntimeNotifier | null | undefined,
+  presentation: RuntimeTerminalPresentation | undefined,
+  worktreeId: string,
+  handle: string,
+  opts: Parameters<NonNullable<RuntimeNotifier['revealTerminalSession']>>[1]
+): Promise<Pick<RuntimeTerminalCreate, 'surface' | 'warning'>> {
+  if (presentation === 'background') {
+    return { surface: 'background' }
+  }
+  if (!notifier?.revealTerminalSession) {
+    return { surface: 'background', warning: createTerminalRevealWarning(handle) }
+  }
+  try {
+    await notifier.revealTerminalSession(worktreeId, opts)
+    return { surface: 'visible' }
+  } catch (error) {
+    console.warn(`[terminal-create] failed to create inactive tab for ${opts.ptyId}:`, error)
+    return { surface: 'background', warning: createTerminalRevealWarning(handle, error) }
+  }
+}

--- a/src/main/runtime/terminal-create-work-origin.ts
+++ b/src/main/runtime/terminal-create-work-origin.ts
@@ -1,0 +1,25 @@
+import type { WorkOrigin } from '../../shared/work-origin'
+import type { PtySpawnResult } from '../providers/pty-spawn-result'
+
+export function resolveTerminalCreateWorkOrigin(
+  runtime: { getPaneWorkOrigin(worktreeId: string, paneKey: string): WorkOrigin | undefined },
+  worktreeId: string,
+  paneKey: string,
+  canAdoptPaneIdentity: boolean,
+  requested: WorkOrigin | undefined
+): WorkOrigin {
+  const retained = canAdoptPaneIdentity ? runtime.getPaneWorkOrigin(worktreeId, paneKey) : undefined
+  return requested !== undefined ? requested : retained === undefined ? { kind: 'host' } : retained
+}
+
+export function applyCreatedTerminalWorkOrigin(
+  pty: { workOrigin?: WorkOrigin },
+  result: PtySpawnResult,
+  requested: WorkOrigin
+): void {
+  if (result.workOrigin !== undefined) {
+    pty.workOrigin = result.workOrigin
+  } else if (!result.isReattach) {
+    pty.workOrigin = requested
+  }
+}

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import type {
   AgentProviderSessionMetadata,
   SleepingAgentLaunchConfig
@@ -31,6 +32,7 @@ export type PtyApi = {
     launchConfig?: SleepingAgentLaunchConfig
     resumeProviderSession?: AgentProviderSessionMetadata
     launchToken?: string
+    workOrigin?: WorkOrigin
     launchAgent?: TuiAgent
     startupCommandDelivery?: StartupCommandDelivery
     connectionId?: string | null
@@ -51,6 +53,7 @@ export type PtyApi = {
     id: string
     /** Which lifetime of `id` this reply named; absent when the execution host predates the field. */
     incarnationId?: string
+    workOrigin?: WorkOrigin
     launchAgent?: TuiAgent
     launchConfig?: SleepingAgentLaunchConfig
     snapshot?: string

--- a/src/preload/api/pty-bridge-session-control.ts
+++ b/src/preload/api/pty-bridge-session-control.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from '../../shared/work-origin'
 import { ipcRenderer } from 'electron'
 import type { AgentSessionPtyWriteRefusal } from '../../shared/agent-session-pty-write-admission'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
@@ -30,6 +31,7 @@ export const ptySessionControlApi = {
     launchConfig?: SleepingAgentLaunchConfig
     resumeProviderSession?: AgentProviderSessionMetadata
     launchToken?: string
+    workOrigin?: WorkOrigin
     launchAgent?: TuiAgent
     startupCommandDelivery?: StartupCommandDelivery
     connectionId?: string | null

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1,3 +1,4 @@
+import { normalizeWorkOrigin, type WorkOrigin } from '../shared/work-origin'
 /* oxlint-disable max-lines */
 import type { IPty } from 'node-pty'
 import type * as NodePty from 'node-pty'
@@ -196,6 +197,7 @@ function parseSourceRecoveryRequest(value: unknown): PtySourceRecoveryRequest | 
 }
 
 type ManagedPty = {
+  workOrigin?: WorkOrigin
   id: string
   incarnationId: string
   pty: IPty
@@ -1834,6 +1836,7 @@ export class PtyHandler {
   ): Promise<{
     id: string
     incarnationId: string
+    workOrigin?: WorkOrigin
     sourceActivation?: PtySourceReceivingActivation
     shellReadyArmed?: boolean
   }> {
@@ -1977,6 +1980,7 @@ export class PtyHandler {
     const managed: ManagedPty = {
       id,
       incarnationId: randomUUID(),
+      workOrigin: normalizeWorkOrigin(params.workOrigin),
       pty: term,
       initialCwd: cwd,
       createdAt: Date.now(),
@@ -2049,6 +2053,7 @@ export class PtyHandler {
     return {
       id,
       incarnationId: managed.incarnationId,
+      workOrigin: managed.workOrigin,
       ...(sourceActivation ? { sourceActivation } : {}),
       shellReadyArmed: rendererShellReadySupported
     }
@@ -2059,6 +2064,7 @@ export class PtyHandler {
     context?: RequestContext
   ): Promise<{
     incarnationId: string
+    workOrigin?: WorkOrigin
     replay?: string
     sourceRecovery?: PtySourceRecoveryResult
     sourceActivation?: PtySourceReceivingActivation
@@ -2157,6 +2163,7 @@ export class PtyHandler {
       if (params.suppressReplayNotification) {
         return {
           incarnationId: managed.incarnationId,
+          workOrigin: managed.workOrigin,
           replay,
           ...(sourceActivation ? { sourceActivation } : {})
         }
@@ -2165,6 +2172,7 @@ export class PtyHandler {
     }
     return {
       incarnationId: managed.incarnationId,
+      workOrigin: managed.workOrigin,
       ...(sourceActivation ? { sourceActivation } : {})
     }
   }

--- a/src/renderer/src/components/terminal-pane/ipc-pty-spawn-request.ts
+++ b/src/renderer/src/components/terminal-pane/ipc-pty-spawn-request.ts
@@ -1,3 +1,4 @@
+import { useAppStore } from '@/store'
 import type { IpcPtyTransportOptions, PtyConnectResult, PtyTransport } from './pty-transport-types'
 
 type PtyConnectOptions = Parameters<PtyTransport['connect']>[0]
@@ -39,6 +40,11 @@ export async function spawnIpcPty(
   const shouldSendLocalCwdFallback =
     cwdFallback === 'worktree' && !connectionId && !admittedSessionId
   return window.api.pty.spawn({
+    workOrigin:
+      worktreeId && tabId
+        ? useAppStore.getState().tabsByWorktree[worktreeId]?.find((tab) => tab.id === tabId)
+            ?.workOrigin
+        : undefined,
     cols: connectOptions.cols ?? 80,
     rows: connectOptions.rows ?? 24,
     cwd,

--- a/src/renderer/src/components/terminal-pane/notification-dispatch-test-state.ts
+++ b/src/renderer/src/components/terminal-pane/notification-dispatch-test-state.ts
@@ -1,0 +1,67 @@
+import type { vi } from 'vitest'
+import type { WorkOrigin } from '../../../../shared/work-origin'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+
+export type MockState = {
+  runtimeEnvironments: { id: string; pairedDeviceId: string }[]
+  activeWorktreeId: string | null
+  activeTabId: string | null
+  tabsByWorktree: Record<
+    string,
+    {
+      id: string
+      ptyId?: string | null
+      workOrigin?: WorkOrigin
+      workOriginsByLeafId?: Record<string, WorkOrigin>
+    }[]
+  >
+  ptyIdsByTabId: Record<string, string[]>
+  suppressedPtyExitIds: Record<string, boolean>
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
+  browserTabsByWorktree: Record<string, unknown[]>
+  retainedAgentsByPaneKey: Record<string, { worktreeId: string }>
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  worktreesByRepo: Record<
+    string,
+    {
+      id: string
+      repoId: string
+      displayName?: string
+      branch?: string
+      workspaceStatus?: string
+    }[]
+  >
+  repos: { id: string; displayName?: string; connectionId?: string | null }[]
+  settings: {
+    experimentalTerminalAttention?: boolean
+    notifications?: {
+      enabled?: boolean
+      customSoundPath?: string | null
+      customSoundId?: string | null
+    }
+  }
+  markWorktreeUnread: ReturnType<typeof vi.fn>
+  markTerminalTabUnread: ReturnType<typeof vi.fn>
+  markTerminalPaneUnread: ReturnType<typeof vi.fn>
+  markAgentCompletionPaneUnread: ReturnType<typeof vi.fn>
+}
+
+export function makeAgentStatus(
+  paneKey: string,
+  overrides: Partial<AgentStatusEntry> = {}
+): AgentStatusEntry {
+  const now = Date.now()
+  return {
+    state: 'done',
+    prompt: 'codex-hook-notify',
+    updatedAt: now,
+    stateStartedAt: now,
+    agentType: 'codex',
+    paneKey,
+    terminalTitle: 'codex',
+    stateHistory: [],
+    lastAssistantMessage: 'Done.',
+    ...overrides
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -1,46 +1,8 @@
+import { makeAgentStatus, type MockState } from './notification-dispatch-test-state'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { dispatchTerminalNotification } from './use-notification-dispatch'
-import {
-  AGENT_STATUS_STALE_AFTER_MS,
-  type AgentStatusEntry
-} from '../../../../shared/agent-status-types'
-import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
-
-type MockState = {
-  activeWorktreeId: string | null
-  activeTabId: string | null
-  tabsByWorktree: Record<string, { id: string; ptyId?: string | null }[]>
-  ptyIdsByTabId: Record<string, string[]>
-  suppressedPtyExitIds: Record<string, boolean>
-  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
-  browserTabsByWorktree: Record<string, unknown[]>
-  retainedAgentsByPaneKey: Record<string, { worktreeId: string }>
-  agentStatusByPaneKey: Record<string, AgentStatusEntry>
-  worktreesByRepo: Record<
-    string,
-    {
-      id: string
-      repoId: string
-      displayName?: string
-      branch?: string
-      workspaceStatus?: string
-    }[]
-  >
-  repos: { id: string; displayName?: string; connectionId?: string | null }[]
-  settings: {
-    experimentalTerminalAttention?: boolean
-    notifications?: {
-      enabled?: boolean
-      customSoundPath?: string | null
-      customSoundId?: string | null
-    }
-  }
-  markWorktreeUnread: ReturnType<typeof vi.fn>
-  markTerminalTabUnread: ReturnType<typeof vi.fn>
-  markTerminalPaneUnread: ReturnType<typeof vi.fn>
-  markAgentCompletionPaneUnread: ReturnType<typeof vi.fn>
-}
 
 const playDesktopNotificationSound = vi.hoisted(() => vi.fn())
 let mockState: MockState
@@ -54,25 +16,6 @@ vi.mock('@/store', () => ({
 vi.mock('@/lib/desktop-notification-sound', () => ({
   playDesktopNotificationSound
 }))
-
-function makeAgentStatus(
-  paneKey: string,
-  overrides: Partial<AgentStatusEntry> = {}
-): AgentStatusEntry {
-  const now = Date.now()
-  return {
-    state: 'done',
-    prompt: 'codex-hook-notify',
-    updatedAt: now,
-    stateStartedAt: now,
-    agentType: 'codex',
-    paneKey,
-    terminalTitle: 'codex',
-    stateHistory: [],
-    lastAssistantMessage: 'Done.',
-    ...overrides
-  }
-}
 
 function stubDocumentFocus({
   visibilityState,
@@ -101,6 +44,7 @@ describe('dispatchTerminalNotification', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockState = {
+      runtimeEnvironments: [],
       activeWorktreeId: 'wt-secondary',
       activeTabId: 'tab-1',
       tabsByWorktree: {
@@ -159,8 +103,67 @@ describe('dispatchTerminalNotification', () => {
     vi.unstubAllGlobals()
   })
 
-  it('uses a live pane key when marking inactive worktree attention', () => {
-    dispatchTerminalNotification('wt-primary', {
+  it.each(['read', 'closed'])(
+    'does not add unread when the pane was %s while IPC was pending',
+    async (action) => {
+      let finish!: (result: { delivered: boolean }) => void
+      vi.mocked(window.api.notifications.dispatch).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve
+          })
+      )
+      const pending = dispatchTerminalNotification('wt-primary', {
+        source: 'agent-task-complete',
+        paneKey
+      })
+      if (action === 'closed') {
+        mockState.tabsByWorktree['wt-primary'] = []
+        mockState.terminalLayoutsByTabId = {}
+        mockState.ptyIdsByTabId = {}
+      } else {
+        mockState.activeWorktreeId = 'wt-primary'
+        stubDocumentFocus({ visibilityState: 'visible', focused: true })
+      }
+      finish({ delivered: false })
+      await pending
+      expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    }
+  )
+
+  it('waits for the host recipient decision before marking unread', async () => {
+    vi.mocked(window.api.notifications.dispatch).mockResolvedValue({
+      delivered: false,
+      reason: 'not-recipient'
+    })
+    await dispatchTerminalNotification('wt-primary', { source: 'agent-task-complete', paneKey })
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+    expect(playDesktopNotificationSound).not.toHaveBeenCalled()
+  })
+
+  it.each(['a', 'b', null])(
+    'isolates remote run origin %s before local phone forwarding',
+    async (deviceId) => {
+      mockState.runtimeEnvironments = [{ id: 'remote-host', pairedDeviceId: 'a' }]
+      mockState.ptyIdsByTabId['tab-1'] = ['remote:remote-host@@term_1']
+      mockState.terminalLayoutsByTabId['tab-1']!.ptyIdsByLeafId = {
+        [liveLeafId]: 'remote:remote-host@@term_1'
+      }
+      mockState.tabsByWorktree['wt-primary']![0]!.workOriginsByLeafId = {
+        [liveLeafId]: deviceId ? { kind: 'paired-device', deviceId } : null
+      }
+      await dispatchTerminalNotification('wt-primary', { source: 'agent-task-complete', paneKey })
+      expect(window.api.notifications.dispatch).toHaveBeenCalledTimes(deviceId === 'a' ? 1 : 0)
+      expect(mockState.markWorktreeUnread).toHaveBeenCalledTimes(deviceId === 'a' ? 1 : 0)
+      if (deviceId === 'a') {
+        expect(getLastNotificationDispatchArg()?.workOrigin).toEqual({ kind: 'host' })
+      }
+    }
+  )
+
+  it('uses a live pane key when marking inactive worktree attention', async () => {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -191,7 +194,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('builds the notification id from a completion snapshot, not the pinned working row', () => {
+  it('builds the notification id from a completion snapshot, not the pinned working row', async () => {
     const pinnedWorkingStartedAt = Date.now() - 60_000
     // Why: the stored row must name the event's agent, or it is dropped for identity mismatch
     // and the assertion would hold whichever side of the `??` wins.
@@ -203,7 +206,7 @@ describe('dispatchTerminalNotification', () => {
     })
     const turnCompletedAt = Date.now()
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'claude',
       paneKey,
@@ -231,7 +234,7 @@ describe('dispatchTerminalNotification', () => {
     { clientStateStartedAt: 2_000, hostTurnCompletedAt: 5_000 }
   ])(
     'accepts a host-stamped completion across client/host clock skew %#',
-    ({ clientStateStartedAt, hostTurnCompletedAt }) => {
+    async ({ clientStateStartedAt, hostTurnCompletedAt }) => {
       mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
         state: 'working',
         stateStartedAt: clientStateStartedAt,
@@ -239,7 +242,7 @@ describe('dispatchTerminalNotification', () => {
         terminalTitle: 'claude'
       })
 
-      dispatchTerminalNotification('wt-primary', {
+      await dispatchTerminalNotification('wt-primary', {
         source: 'agent-task-complete',
         terminalTitle: 'claude',
         paneKey,
@@ -259,7 +262,7 @@ describe('dispatchTerminalNotification', () => {
     }
   )
 
-  it('drops a host-stamped completion after a newer client turn starts', () => {
+  it('drops a host-stamped completion after a newer client turn starts', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       stateStartedAt: 6_000,
@@ -267,7 +270,7 @@ describe('dispatchTerminalNotification', () => {
       terminalTitle: 'claude'
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'claude',
       paneKey,
@@ -284,10 +287,10 @@ describe('dispatchTerminalNotification', () => {
     expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
   })
 
-  it('uses a live pane key when inactive worktree tab membership is not hydrated', () => {
+  it('uses a live pane key when inactive worktree tab membership is not hydrated', async () => {
     mockState.tabsByWorktree = {}
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -305,10 +308,10 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('uses tab liveness when the layout has the leaf but no leaf pty binding yet', () => {
+  it('uses tab liveness when the layout has the leaf but no leaf pty binding yet', async () => {
     mockState.terminalLayoutsByTabId['tab-1'].ptyIdsByLeafId = {}
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -326,10 +329,10 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('falls back to background-worktree unread when terminal attention is disabled', () => {
+  it('falls back to background-worktree unread when terminal attention is disabled', async () => {
     mockState.settings.experimentalTerminalAttention = false
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -342,9 +345,9 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markAgentCompletionPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('offers attention-only completion to main for independent mobile delivery', () => {
+  it('offers attention-only completion to main for independent mobile delivery', async () => {
     mockState.settings.notifications = { ...mockState.settings.notifications, enabled: false }
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -356,11 +359,11 @@ describe('dispatchTerminalNotification', () => {
     expect(window.api.notifications.dispatch).toHaveBeenCalled()
   })
 
-  it('does not mark the visible focused pane unread', () => {
+  it('does not mark the visible focused pane unread', async () => {
     mockState.activeWorktreeId = 'wt-primary'
     stubDocumentFocus({ visibilityState: 'visible', focused: true })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -373,7 +376,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markAgentCompletionPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('marks a hidden tab in the focused worktree unread', () => {
+  it('marks a hidden tab in the focused worktree unread', async () => {
     const hiddenLeafId = '33333333-3333-4333-8333-333333333333'
     const hiddenPaneKey = `tab-2:${hiddenLeafId}`
     mockState.activeWorktreeId = 'wt-primary'
@@ -389,7 +392,7 @@ describe('dispatchTerminalNotification', () => {
     mockState.agentStatusByPaneKey[hiddenPaneKey] = makeAgentStatus(hiddenPaneKey)
     stubDocumentFocus({ visibilityState: 'visible', focused: true })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey: hiddenPaneKey
@@ -401,7 +404,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(hiddenPaneKey)
   })
 
-  it('marks a hidden split pane in the focused tab unread', () => {
+  it('marks a hidden split pane in the focused tab unread', async () => {
     const siblingPaneKey = stalePaneKey
     mockState.activeWorktreeId = 'wt-primary'
     mockState.activeTabId = 'tab-1'
@@ -420,7 +423,7 @@ describe('dispatchTerminalNotification', () => {
     mockState.agentStatusByPaneKey[siblingPaneKey] = makeAgentStatus(siblingPaneKey)
     stubDocumentFocus({ visibilityState: 'visible', focused: true })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey: siblingPaneKey
@@ -432,12 +435,12 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(siblingPaneKey)
   })
 
-  it('marks the selected worktree unread when Orca is backgrounded', () => {
+  it('marks the selected worktree unread when Orca is backgrounded', async () => {
     mockState.settings.experimentalTerminalAttention = false
     mockState.activeWorktreeId = 'wt-primary'
     stubDocumentFocus({ visibilityState: 'hidden', focused: false })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -450,12 +453,12 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markAgentCompletionPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('drops a pane key when its tab is hydrated under another worktree', () => {
+  it('drops a pane key when its tab is hydrated under another worktree', async () => {
     mockState.tabsByWorktree = {
       'wt-secondary': [{ id: 'tab-1' }]
     }
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -467,10 +470,10 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('does not mark unread for a stale closed pane key when another pty in the tab is live', () => {
+  it('does not mark unread for a stale closed pane key when another pty in the tab is live', async () => {
     mockState.agentStatusByPaneKey[stalePaneKey] = makeAgentStatus(stalePaneKey)
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey: stalePaneKey
@@ -482,10 +485,10 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('uses a fresh hook snapshot when inactive PTY liveness has not caught up', () => {
+  it('uses a fresh hook snapshot when inactive PTY liveness has not caught up', async () => {
     mockState.ptyIdsByTabId = {}
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey
@@ -507,12 +510,12 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('uses accepted hook snapshot timing for the notification id when the live store row is gone before dispatch', () => {
+  it('uses accepted hook snapshot timing for the notification id when the live store row is gone before dispatch', async () => {
     mockState.ptyIdsByTabId = {}
     mockState.agentStatusByPaneKey = {}
     const stateStartedAt = Date.now() - 1_000
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey,
@@ -546,7 +549,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('does not let fresh active status suppress a completion from another named agent', () => {
+  it('does not let fresh active status suppress a completion from another named agent', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       agentType: 'codex',
@@ -554,7 +557,7 @@ describe('dispatchTerminalNotification', () => {
       lastAssistantMessage: undefined
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: '✳ Claude Code',
       paneKey
@@ -573,10 +576,10 @@ describe('dispatchTerminalNotification', () => {
     expect(dispatchArgs?.agentLastAssistantMessage).toBeUndefined()
   })
 
-  it('does not reuse an event snapshot when the terminal title names another agent', () => {
+  it('does not reuse an event snapshot when the terminal title names another agent', async () => {
     mockState.agentStatusByPaneKey = {}
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: '✳ Claude Code',
       paneKey,
@@ -604,14 +607,14 @@ describe('dispatchTerminalNotification', () => {
     expect(dispatchArgs?.agentLastAssistantMessage).toBeUndefined()
   })
 
-  it('does not reuse an untyped fresh agent snapshot when the terminal title names an agent', () => {
+  it('does not reuse an untyped fresh agent snapshot when the terminal title names an agent', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       agentType: undefined,
       terminalTitle: 'unknown',
       lastAssistantMessage: 'Previous agent done.'
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'Claude Code',
       paneKey
@@ -630,14 +633,14 @@ describe('dispatchTerminalNotification', () => {
     expect(dispatchArgs?.agentLastAssistantMessage).toBeUndefined()
   })
 
-  it('keeps a fresh agent snapshot when the terminal title matches the stored agent', () => {
+  it('keeps a fresh agent snapshot when the terminal title matches the stored agent', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       agentType: 'codex',
       terminalTitle: 'Codex',
       lastAssistantMessage: 'Codex done.'
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: '⠋ Codex',
       paneKey
@@ -652,7 +655,7 @@ describe('dispatchTerminalNotification', () => {
     )
   })
 
-  it('drops a title-only completion when fresh hook state is still active', () => {
+  it('drops a title-only completion when fresh hook state is still active', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       prompt: 'still running',
@@ -661,7 +664,7 @@ describe('dispatchTerminalNotification', () => {
       lastAssistantMessage: undefined
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: '✳ Launch UI and thumbnail generator',
       paneKey
@@ -674,7 +677,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('allows confirmed process-exit completion while fresh hook state is still active', () => {
+  it('allows confirmed process-exit completion while fresh hook state is still active', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       prompt: 'agent crashed before its done hook',
@@ -683,7 +686,7 @@ describe('dispatchTerminalNotification', () => {
       lastAssistantMessage: undefined
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey,
@@ -708,7 +711,7 @@ describe('dispatchTerminalNotification', () => {
 
   it.each([undefined, 'unknown'] as const)(
     'drops an explicitly named title completion when fresh hook identity is %s',
-    (agentType) => {
+    async (agentType) => {
       mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
         state: 'working',
         agentType,
@@ -717,7 +720,7 @@ describe('dispatchTerminalNotification', () => {
         lastAssistantMessage: undefined
       })
 
-      dispatchTerminalNotification('wt-primary', {
+      await dispatchTerminalNotification('wt-primary', {
         source: 'agent-task-complete',
         terminalTitle: 'Claude Code done',
         paneKey
@@ -731,7 +734,7 @@ describe('dispatchTerminalNotification', () => {
     }
   )
 
-  it('drops a Pi title completion while compatible OMP hook status is active', () => {
+  it('drops a Pi title completion while compatible OMP hook status is active', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       agentType: 'omp',
@@ -740,7 +743,7 @@ describe('dispatchTerminalNotification', () => {
       lastAssistantMessage: undefined
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'Pi ready',
       paneKey
@@ -753,7 +756,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('allows title-only completion after active hook status becomes stale', () => {
+  it('allows title-only completion after active hook status becomes stale', async () => {
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
       updatedAt: Date.now() - AGENT_STATUS_STALE_AFTER_MS - 1,
@@ -761,7 +764,7 @@ describe('dispatchTerminalNotification', () => {
       lastAssistantMessage: undefined
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: '/workspace/orca',
       paneKey
@@ -771,7 +774,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
   })
 
-  it('drops a delayed completion snapshot when the pane has already started a newer turn', () => {
+  it('drops a delayed completion snapshot when the pane has already started a newer turn', async () => {
     const previousDoneStartedAt = Date.now() - 10_000
     mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
       state: 'working',
@@ -781,7 +784,7 @@ describe('dispatchTerminalNotification', () => {
       lastAssistantMessage: undefined
     })
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey,
@@ -801,12 +804,12 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('drops accepted hook snapshots for an intentionally suppressed pty', () => {
+  it('drops accepted hook snapshots for an intentionally suppressed pty', async () => {
     mockState.ptyIdsByTabId = {}
     mockState.agentStatusByPaneKey = {}
     mockState.suppressedPtyExitIds = { 'pty-1': true }
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey,
@@ -824,10 +827,10 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('drops final-flush notifications for suppressed live ptys', () => {
+  it('drops final-flush notifications for suppressed live ptys', async () => {
     mockState.suppressedPtyExitIds = { 'pty-1': true }
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'terminal-bell',
       terminalTitle: 'codex',
       paneKey
@@ -839,7 +842,7 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('drops layout-fallback notifications when all tab PTYs are suppressed', () => {
+  it('drops layout-fallback notifications when all tab PTYs are suppressed', async () => {
     mockState.suppressedPtyExitIds = { 'pty-1': true }
     mockState.terminalLayoutsByTabId['tab-1'] = {
       root: { type: 'leaf', leafId: 'leaf-1' },
@@ -848,7 +851,7 @@ describe('dispatchTerminalNotification', () => {
       ptyIdsByLeafId: {}
     }
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'terminal-bell',
       terminalTitle: 'codex',
       paneKey
@@ -860,14 +863,14 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('still drops stale notifications when neither pty liveness nor fresh hook status exists', () => {
+  it('still drops stale notifications when neither pty liveness nor fresh hook status exists', async () => {
     mockState.ptyIdsByTabId = {}
     mockState.agentStatusByPaneKey[paneKey] = {
       ...makeAgentStatus(paneKey),
       updatedAt: Date.now() - 11_000
     }
 
-    dispatchTerminalNotification('wt-primary', {
+    await dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
       paneKey

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -1,3 +1,7 @@
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { workOriginAllowsHost, workOriginMatchesDevice } from '../../../../shared/work-origin'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
 import { useCallback } from 'react'
 import { useAppStore } from '@/store'
 import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
@@ -65,11 +69,34 @@ export type TerminalNotificationEvent = {
  * creates a new array reference on every store update and triggers
  * excessive re-renders of TerminalPane.
  */
-export function dispatchTerminalNotification(
+export async function dispatchTerminalNotification(
   worktreeId: string,
   event: TerminalNotificationEvent
-): void {
+): Promise<void> {
   const state = useAppStore.getState()
+  const pane = event.paneKey ? parsePaneKey(event.paneKey) : null
+  const tab = pane
+    ? state.tabsByWorktree[worktreeId]?.find((tab) => tab.id === pane.tabId)
+    : undefined
+  const ptyId = pane
+    ? (state.terminalLayoutsByTabId[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId] ?? tab?.ptyId)
+    : undefined
+  const environmentId =
+    (ptyId ? getRemoteRuntimePtyEnvironmentId(ptyId) : null) ??
+    getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  const leafOrigin = pane ? tab?.workOriginsByLeafId?.[pane.leafId] : undefined
+  const origin = leafOrigin === undefined ? tab?.workOrigin : leafOrigin
+  if (environmentId) {
+    const deviceId = state.runtimeEnvironments.find(
+      (environment) => environment.id === environmentId
+    )?.pairedDeviceId
+    if (!deviceId || !workOriginMatchesDevice(origin, deviceId)) {
+      return
+    }
+  }
+  const localRecipient = environmentId !== null || workOriginAllowsHost(origin)
+  let markUnread: (() => void) | undefined
+
   // Why: the completion title is the live identity. If it explicitly names an
   // agent, any snapshot from another agent is stale pane-reuse residue and must
   // not lend its prompt/agentType or timing id to this notification.
@@ -157,18 +184,33 @@ export function dispatchTerminalNotification(
     const shouldMarkUnread = event.paneKey
       ? !isVisibleForegroundPaneKey(state, worktreeId, event.paneKey)
       : state.activeWorktreeId !== worktreeId || !isOrcaWindowForegroundFocused()
-    if (shouldMarkUnread) {
-      // Why: activeWorktreeId is only in-app selection. If Orca is backgrounded,
-      // a selected chat finishing still needs unread/Dock attention.
-      state.markWorktreeUnread(worktreeId)
-      if (event.paneKey) {
-        // Why: focus-return auto-ack needs an agent-specific source marker;
-        // generic pane unread also covers BEL and must still show until interact.
-        state.markAgentCompletionPaneUnread(event.paneKey)
-      }
-      if (terminalAttentionEnabled && tabId && event.paneKey) {
-        state.markTerminalTabUnread(tabId)
-        state.markTerminalPaneUnread(event.paneKey)
+    if (localRecipient && shouldMarkUnread) {
+      markUnread = () => {
+        const current = useAppStore.getState()
+        if (event.paneKey) {
+          if (
+            (!isCurrentLivePaneKey(current, worktreeId, event.paneKey) &&
+              !isCurrentKnownPaneKey(current, worktreeId, event.paneKey)) ||
+            isVisibleForegroundPaneKey(current, worktreeId, event.paneKey)
+          ) {
+            return
+          }
+        } else if (current.activeWorktreeId === worktreeId && isOrcaWindowForegroundFocused()) {
+          return
+        }
+
+        // Why: activeWorktreeId is only in-app selection. If Orca is backgrounded,
+        // a selected chat finishing still needs unread/Dock attention.
+        current.markWorktreeUnread(worktreeId)
+        if (event.paneKey) {
+          // Why: focus-return auto-ack needs an agent-specific source marker;
+          // generic pane unread also covers BEL and must still show until interact.
+          current.markAgentCompletionPaneUnread(event.paneKey)
+        }
+        if (terminalAttentionEnabled && tabId && event.paneKey) {
+          current.markTerminalTabUnread(tabId)
+          current.markTerminalPaneUnread(event.paneKey)
+        }
       }
     }
   }
@@ -209,9 +251,10 @@ export function dispatchTerminalNotification(
         })
       : null
 
-  void window.api.notifications
+  return window.api.notifications
     .dispatch({
       source: event.source,
+      workOrigin: environmentId ? { kind: 'host' } : origin,
       ...(notificationId ? { notificationId } : {}),
       worktreeId,
       paneKey: event.paneKey,
@@ -223,6 +266,10 @@ export function dispatchTerminalNotification(
       ...agentSnapshot
     })
     .then((result) => {
+      if (result.reason === 'not-recipient') {
+        return
+      }
+      markUnread?.()
       if (result.delivered) {
         void playDesktopNotificationSound(customSoundId, customSoundVolume)
         return

--- a/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
@@ -79,6 +79,16 @@ export function registerTerminalRequestIpcBridge(unsubs: (() => void)[]): void {
                 ...(data.cwd ? { startupCwd: data.cwd } : {})
               }
         const tab = store.createTab(worktreeId, data.targetGroupId, undefined, tabOptions)
+        if (data.workOrigin !== undefined) {
+          useAppStore.setState((state) => ({
+            tabsByWorktree: {
+              ...state.tabsByWorktree,
+              [worktreeId]: state.tabsByWorktree[worktreeId].map((row) =>
+                row.id === tab.id ? { ...row, workOrigin: data.workOrigin } : row
+              )
+            }
+          }))
+        }
         if (!shouldActivate) {
           // Why: renderer-backed Codex startup must mount its new TerminalPane without switching UI or connecting every saved tab.
           requestBackgroundTerminalWorktreeMount({ worktreeId, tabIds: [tab.id] })

--- a/src/renderer/src/runtime/runtime-client-events.test.ts
+++ b/src/renderer/src/runtime/runtime-client-events.test.ts
@@ -1,9 +1,50 @@
+import { useAppStore } from '../store'
 import { describe, expect, it, vi } from 'vitest'
 import type { SshProviderEpoch } from '../../../shared/ssh-types'
 import { subscribeRuntimeClientEvents } from './runtime-client-events'
 import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
 
 describe('subscribeRuntimeClientEvents', () => {
+  it('accepts only addressed activation and rejects old-host broadcasts', async () => {
+    let receive!: (response: unknown) => void
+    vi.stubGlobal('window', {
+      api: {
+        runtimeEnvironments: {
+          subscribe: vi.fn(async (_args, callbacks) => {
+            receive = callbacks.onResponse
+            return { unsubscribe: vi.fn() }
+          })
+        }
+      }
+    })
+    const prior = useAppStore.getState().runtimeEnvironments
+    useAppStore.setState({ runtimeEnvironments: [{ id: 'env-a', pairedDeviceId: 'a' }] as never })
+    try {
+      const onEvent = vi.fn()
+      const subscription = await subscribeRuntimeClientEvents('env-a', onEvent)
+      for (const recipientDeviceId of [undefined, 'b', 'a']) {
+        receive({
+          ok: true,
+          result: {
+            type: 'activateWorktree',
+            repoId: 'repo',
+            worktreeId: 'worktree',
+            recipientDeviceId
+          }
+        })
+      }
+      expect(onEvent).toHaveBeenCalledExactlyOnceWith({
+        type: 'activateWorktree',
+        repoId: 'repo',
+        worktreeId: 'worktree',
+        recipientDeviceId: 'a'
+      })
+      subscription.unsubscribe()
+    } finally {
+      useAppStore.setState({ runtimeEnvironments: prior })
+    }
+  })
+
   it('subscribes to runtime client events and forwards event frames', async () => {
     replaceRuntimeEnvironmentRevisions([{ id: 'env-1', createdAt: 1, pairingRevision: 7 }])
     const unsubscribe = vi.fn()

--- a/src/renderer/src/runtime/runtime-client-events.ts
+++ b/src/renderer/src/runtime/runtime-client-events.ts
@@ -1,3 +1,4 @@
+import { useAppStore } from '../store'
 import type {
   RuntimeClientEvent,
   RuntimeClientEventStreamMessage
@@ -30,7 +31,25 @@ export async function subscribeRuntimeClientEvents(
     },
     {
       onResponse: (response) => {
-        handleRuntimeClientEventResponse(response, onEvent, onError, onReplayedAfterReconnect)
+        handleRuntimeClientEventResponse(
+          response,
+          (event) => {
+            if (event.type === 'activateWorktree') {
+              const environment = useAppStore
+                .getState()
+                .runtimeEnvironments.find((entry) => entry.id === environmentId)
+              if (
+                !event.recipientDeviceId ||
+                event.recipientDeviceId !== environment?.pairedDeviceId
+              ) {
+                return
+              }
+            }
+            onEvent(event)
+          },
+          onError,
+          onReplayedAfterReconnect
+        )
       },
       onError
     }

--- a/src/renderer/src/runtime/web-session-tabs-sync-focus-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-focus-intent.test.ts
@@ -157,8 +157,8 @@ describe('applyWebSessionTabsSnapshot', () => {
       ENV,
       NOW + 10
     ) as Partial<WebSessionTabsSyncState>
-    expect(followed.activeTabIdByWorktree?.[WT]).toBe(agentTabId)
-    expect(followed.groupsByWorktree?.[WT]?.[0]?.activeTabId).toBe(agentTabId)
+    expect(followed.activeTabIdByWorktree).toBeUndefined()
+    expect(followed.groupsByWorktree).toBeUndefined()
   })
 
   it('does not let stale browser intent override a newer terminal selection', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync/apply-preparation-base.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/apply-preparation-base.ts
@@ -87,11 +87,7 @@ export function prepareWebSessionTabsSnapshotBase(
       expectedCurrentLocalTabId === currentVisibleLocalTabId)
       ? matchingFocusIntentTab
       : null
-  const followIntentTab =
-    snapshot.navigationIntent === 'follow'
-      ? (snapshot.tabs.find((tab) => tab.id === snapshot.activeTabId) ?? null)
-      : null
-  const navigationIntentTab = callerFocusIntentTab ?? followIntentTab
+  const navigationIntentTab = callerFocusIntentTab
   const honorSnapshotActiveFocus = navigationIntentTab !== null
   if (matchingFocusIntentTab) {
     clearWebSessionFocusIntent({ environmentId }, worktreeId)

--- a/src/renderer/src/runtime/web-session-tabs-sync/state-equality-tabs.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/state-equality-tabs.ts
@@ -28,6 +28,7 @@ export function terminalTabEqual(a: TerminalTab, b: TerminalTab): boolean {
     a.generation === b.generation &&
     a.shellOverride === b.shellOverride &&
     a.launchAgent === b.launchAgent &&
+    JSON.stringify(a.workOriginsByLeafId) === JSON.stringify(b.workOriginsByLeafId) &&
     a.pendingActivationSpawn === b.pendingActivationSpawn
   )
 }

--- a/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
@@ -163,6 +163,13 @@ export function buildMirroredTerminalTabs(
     return {
       tab: {
         id: localTabId,
+        workOriginsByLeafId: Object.fromEntries(
+          surfaces.flatMap((surface) =>
+            surface.workOrigin === undefined && terminalPtyMode === 'local'
+              ? []
+              : [[surface.leafId, surface.workOrigin ?? null]]
+          )
+        ),
         ptyId: ptyIdsByLeafId[activeSurface.leafId] ?? null,
         worktreeId: snapshot.worktree,
         title,

--- a/src/shared/agent-session-launch-args.ts
+++ b/src/shared/agent-session-launch-args.ts
@@ -1,0 +1,13 @@
+import type { AgentSessionLaunchArgs } from './agent-session-record'
+
+const MAX_LAUNCH_ARGS = 256
+const MAX_LAUNCH_ARGS_BYTES = 16 * 1024
+
+export function isAgentSessionLaunchArgs(value: unknown): value is AgentSessionLaunchArgs {
+  return (
+    Array.isArray(value) &&
+    value.length <= MAX_LAUNCH_ARGS &&
+    value.every((arg) => typeof arg === 'string' && !arg.includes('\0')) &&
+    Buffer.byteLength(JSON.stringify(value), 'utf8') <= MAX_LAUNCH_ARGS_BYTES
+  )
+}

--- a/src/shared/agent-session-record.ts
+++ b/src/shared/agent-session-record.ts
@@ -1,3 +1,6 @@
+import { isAgentSessionLaunchArgs } from './agent-session-launch-args'
+export { isAgentSessionLaunchArgs } from './agent-session-launch-args'
+import { normalizeWorkOrigin, type WorkOrigin } from './work-origin'
 import { isAgentSessionRewindRecord, type AgentSessionRewindRecord } from './agent-session-rewind'
 import { isAgentSessionConversationName } from './agent-session-conversation-name'
 /**
@@ -123,6 +126,7 @@ export type AgentSessionLease = {
 }
 
 export type AgentSessionRecord = {
+  workOrigin?: WorkOrigin
   schemaVersion: typeof AGENT_SESSION_RECORD_SCHEMA_VERSION
   sessionId: string
   location: AgentSessionExecutionLocation
@@ -152,8 +156,6 @@ const MAX_ID_LENGTH = 512
 const MAX_PATH_LENGTH = 4096
 const MAX_LAUNCH_ENV_ENTRIES = 256
 const MAX_LAUNCH_ENV_VALUE_LENGTH = 65_536
-const MAX_LAUNCH_ARGS = 256
-const MAX_LAUNCH_ARGS_BYTES = 16 * 1024
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/
 
 function isBoundedString(value: unknown, max: number): value is string {
@@ -338,6 +340,9 @@ export function isAgentSessionRecord(value: unknown): value is AgentSessionRecor
   }
   const record = value as Partial<AgentSessionRecord>
   const shapeValid =
+    (record.workOrigin === undefined ||
+      record.workOrigin === null ||
+      normalizeWorkOrigin(record.workOrigin) !== null) &&
     record.schemaVersion === AGENT_SESSION_RECORD_SCHEMA_VERSION &&
     isAgentSessionId(record.sessionId) &&
     isAgentSessionExecutionLocation(record.location) &&
@@ -367,14 +372,5 @@ export function isAgentSessionRecord(value: unknown): value is AgentSessionRecor
       (validated.lease.ownerProcess !== null &&
         head?.linkId === validated.lease.provenHandleLinkId &&
         head.mintedAtFence === validated.lease.runtimeFence))
-  )
-}
-
-export function isAgentSessionLaunchArgs(value: unknown): value is AgentSessionLaunchArgs {
-  return (
-    Array.isArray(value) &&
-    value.length <= MAX_LAUNCH_ARGS &&
-    value.every((arg) => typeof arg === 'string' && !arg.includes('\0')) &&
-    Buffer.byteLength(JSON.stringify(value), 'utf8') <= MAX_LAUNCH_ARGS_BYTES
   )
 }

--- a/src/shared/notification-settings-types.ts
+++ b/src/shared/notification-settings-types.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from './work-origin'
 import type { AgentStatusState, AgentType } from './agent-status-types'
 
 export type NotificationSettings = {
@@ -25,6 +26,7 @@ export type NotificationEventSource = 'agent-task-complete' | 'terminal-bell' | 
 
 export type NotificationDispatchRequest = {
   source: NotificationEventSource
+  workOrigin?: WorkOrigin
   notificationId?: string
   /** Why: useful for fast native failures, but macOS can still drop notifications after 'show'. */
   requireDisplayConfirmation?: boolean
@@ -49,6 +51,7 @@ export type NotificationDispatchResult = {
   delivered: boolean
   /** Why delivery was skipped (set when delivered is false); 'blocked-by-system' = macOS would silently swallow it. */
   reason?:
+    | 'not-recipient'
     | 'disabled'
     | 'source-disabled'
     | 'suppressed-focus'

--- a/src/shared/rpc-contract/terminal-unary-params.ts
+++ b/src/shared/rpc-contract/terminal-unary-params.ts
@@ -140,6 +140,9 @@ export const TerminalWait = TerminalHandle.extend({
 })
 
 export const TerminalCreateParams = z.object({
+  callerOriginSession: z.object({ sessionId: z.string(), spawnToken: z.string() }).optional(),
+  callerTerminalHandle: z.string().optional(),
+  cliProvenanceRequest: z.object({}).optional(),
   worktree: OptionalString,
   clientMutationId: z.string().min(1).max(128).optional(),
   reconcileExisting: z.boolean().optional(),
@@ -184,6 +187,9 @@ export const TerminalCreateParams = z.object({
 })
 
 export const TerminalSplit = TerminalHandle.extend({
+  callerOriginSession: z.object({ sessionId: z.string(), spawnToken: z.string() }).optional(),
+  callerTerminalHandle: OptionalString,
+  cliProvenanceRequest: z.object({}).optional(),
   direction: z
     .unknown()
     .transform((v) => (v === 'vertical' || v === 'horizontal' ? v : undefined))

--- a/src/shared/rpc-contract/worktree-create-params.ts
+++ b/src/shared/rpc-contract/worktree-create-params.ts
@@ -83,6 +83,7 @@ export const WorktreeCreate = z
     parentWorktree: OptionalString,
     cwdParentWorktree: OptionalString,
     noParent: OptionalBoolean,
+    callerOriginSession: z.object({ sessionId: z.string(), spawnToken: z.string() }).optional(),
     callerTerminalHandle: OptionalString,
     orchestrationContext: z
       .object({

--- a/src/shared/runtime-client-events.ts
+++ b/src/shared/runtime-client-events.ts
@@ -40,6 +40,7 @@ export type RuntimeClientEvent =
     }
   | {
       type: 'activateWorktree'
+      recipientDeviceId?: string
       repoId: string
       worktreeId: string
       setup?: WorktreeSetupLaunch

--- a/src/shared/runtime-mobile-session-tab-contracts.ts
+++ b/src/shared/runtime-mobile-session-tab-contracts.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from './work-origin'
 import type { AgentStatusEntry } from './agent-status-types'
 import type { BrowserCertificateFailure, BrowserLoadError } from './browser-workspace-types'
 import type { RuntimeBrowserPlacement } from './runtime-browser-placement'
@@ -6,6 +7,7 @@ import type { TerminalLayoutSnapshot } from './terminal-tab-types'
 import type { TuiAgent } from './tui-agent'
 
 export type RuntimeMobileSessionTerminalTab = {
+  workOrigin?: WorkOrigin
   type: 'terminal'
   id: string
   title: string

--- a/src/shared/runtime-navigation.ts
+++ b/src/shared/runtime-navigation.ts
@@ -7,14 +7,11 @@ export function resolveRuntimeNavigationTarget(args: {
   notifyClients?: boolean
   clientKind?: 'mobile' | 'runtime'
 }): RuntimeNavigationTarget {
-  if (args.navigation) {
-    return args.navigation
-  }
   if (args.clientKind) {
     // Why: legacy paired clients sent notifyClients:true; treating that as navigation lets one device steer every UI.
     return 'caller'
   }
-  return args.notifyClients === false ? 'caller' : 'all'
+  return args.navigation ?? (args.notifyClients === false ? 'caller' : 'all')
 }
 
 export function navigationTargetsHost(target: RuntimeNavigationTarget): boolean {

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -1,8 +1,6 @@
+import type { WorkOrigin } from './work-origin'
 import type { AgentSessionPtyWriteRefusal } from './agent-session-pty-write-admission'
-import type {
-  AgentProviderSessionMetadata,
-  SleepingAgentLaunchConfig
-} from './agent-session-resume'
+import type * as AgentSessionResume from './agent-session-resume'
 import type { StartupCommandDelivery } from './codex-startup-delivery'
 import type { ExecutionHostId } from './execution-host'
 import type { PtyIncarnationId } from './pty-incarnation'
@@ -245,6 +243,7 @@ export type RuntimeTerminalAgentStatus = {
 export type RuntimeTerminalPresentation = 'background' | 'focused'
 
 type RuntimeTerminalCreateBaseRequestPayload = {
+  workOrigin?: WorkOrigin
   requestId: string
   worktreeId?: string
   afterTabId?: string
@@ -253,8 +252,8 @@ type RuntimeTerminalCreateBaseRequestPayload = {
   cwd?: string
   env?: Record<string, string>
   envToDelete?: string[]
-  launchConfig?: SleepingAgentLaunchConfig
-  resumeProviderSession?: AgentProviderSessionMetadata
+  launchConfig?: AgentSessionResume.SleepingAgentLaunchConfig
+  resumeProviderSession?: AgentSessionResume.AgentProviderSessionMetadata
   launchToken?: string
   launchAgent?: TuiAgent
   viewMode?: 'terminal' | 'chat'

--- a/src/shared/terminal-tab-types.ts
+++ b/src/shared/terminal-tab-types.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from './work-origin'
 import type { AiVaultSessionTitle } from './ai-vault-session-title'
 import type { TuiAgent } from './tui-agent'
 
@@ -55,6 +56,8 @@ export type TerminalTabRecoveryLedger = {
 
 // ─── Terminal Tab (legacy — used by persistence and TerminalContentSlice) ─
 export type TerminalTab = {
+  workOrigin?: WorkOrigin
+  workOriginsByLeafId?: Record<string, WorkOrigin>
   id: string
   ptyId: string | null
   worktreeId: string

--- a/src/shared/work-origin.ts
+++ b/src/shared/work-origin.ts
@@ -1,0 +1,30 @@
+import type { WorkspaceCreatorProvenance } from './worktree/types'
+import { normalizeWorkspaceCreatorProvenance } from './workspace-creator-provenance'
+
+export type WorkOrigin = WorkspaceCreatorProvenance | null
+
+export function normalizeWorkOrigin(value: unknown): WorkOrigin | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  return normalizeWorkspaceCreatorProvenance(value) ?? null
+}
+
+export function workOriginMatchesDevice(origin: WorkOrigin | undefined, deviceId: string): boolean {
+  return origin?.kind === 'paired-device' && origin.deviceId === deviceId
+}
+
+export function workOriginAllowsHost(origin: WorkOrigin | undefined): boolean {
+  // Legacy host-local sessions keep working; explicit unknown is never host ownership.
+  return origin === undefined || origin?.kind === 'host'
+}
+
+export function workOriginAllowsDevice(
+  origin: WorkOrigin | undefined,
+  deviceId: string | undefined
+): boolean {
+  return (
+    workOriginAllowsHost(origin) ||
+    (deviceId !== undefined && workOriginMatchesDevice(origin, deviceId))
+  )
+}

--- a/src/shared/workspace-session-host-field-ownership.ts
+++ b/src/shared/workspace-session-host-field-ownership.ts
@@ -48,6 +48,7 @@ export const WORKSPACE_SESSION_FIELD_OWNERSHIP = {
   markdownFrontmatterVisible: 'fileKeyed',
   sleepingAgentSessionsByPaneKey: 'sleepingAgentKeyed',
   terminalPtyIncarnationsByPaneKey: 'paneKeyed',
+  terminalWorkOriginsByPaneKey: 'paneKeyed',
   // Why: this host-issued fence must never collide while unified renderer state merges equal repo ids across hosts.
   terminalTopologyRevisionByRepoId: 'hostPrivate',
   terminalSurfaceTombstonesByPaneKey: 'surfaceTombstoneKeyed',

--- a/src/shared/workspace-session-schema-field-coverage.test.ts
+++ b/src/shared/workspace-session-schema-field-coverage.test.ts
@@ -51,6 +51,7 @@ const PERSISTED_WORKSPACE_SESSION_FIELDS = {
   defaultTerminalTabsAppliedByWorktreeId: true,
   sleepingAgentSessionsByPaneKey: true,
   terminalPtyIncarnationsByPaneKey: true,
+  terminalWorkOriginsByPaneKey: true,
   terminalTopologyRevisionByRepoId: true,
   terminalSurfaceTombstonesByPaneKey: true,
   closedTerminalTabTombstonesByTabId: true

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -297,6 +297,17 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
     'sleepingAgentSessionsByPaneKey',
     sleepingAgentSessionsByPaneKeySchema
   ),
+  terminalWorkOriginsByPaneKey: salvagedOptional(
+    'terminalWorkOriginsByPaneKey',
+    salvagingRecord(
+      z.string(),
+      z.union([
+        z.object({ kind: z.literal('host') }),
+        z.object({ kind: z.literal('paired-device'), deviceId: z.string().min(1) }),
+        z.null()
+      ])
+    )
+  ),
   terminalPtyIncarnationsByPaneKey: salvagedOptional(
     'terminalPtyIncarnationsByPaneKey',
     salvagingRecord(z.string(), z.string().min(1).max(128))

--- a/src/shared/workspace-session-state-types.ts
+++ b/src/shared/workspace-session-state-types.ts
@@ -1,3 +1,4 @@
+import type { WorkOrigin } from './work-origin'
 import type { ExecutionHostId } from './execution-host'
 import type { SleepingAgentSessionRecord } from './agent-session-resume'
 import type { WorkspaceKey } from './folder-workspace-types'
@@ -113,6 +114,7 @@ export type WorkspaceSessionState = {
   /** Provider-session resume records captured when workspaces sleep. */
   sleepingAgentSessionsByPaneKey?: Record<string, SleepingAgentSessionRecord>
   /** Host-issued process incarnation for each durable terminal surface. */
+  terminalWorkOriginsByPaneKey?: Record<string, WorkOrigin>
   terminalPtyIncarnationsByPaneKey?: Record<string, string>
   /** Monotonic host authority watermark for terminal membership in each repo. */
   terminalTopologyRevisionByRepoId?: Record<string, number>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​527 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​206 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​321 |
| Prod | 110 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​939 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​253 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​686 |

<!-- /orca-pr-loc -->

## ELI5

When two clients share a remote Orca server, work started by one client should not switch the other client's workspace or send it agent notifications. Track the initiating device on each run and use it to route activation and alerts, without adding a subscribe/follow UI.

## What Changed

- Reuse host/paired-device provenance for run origin, preserving it through terminal creation, child CLI commands, native sessions, persistence, and daemon/SSH reattachment.
- Address CLI activation to the originating client and keep paired UI navigation caller-local, including legacy explicit broadcast targets. Unknown origins remain background; reconnect does not replay activation.
- Provision setup/default terminals independently of reveal, including folder and SSH workspaces.
- Filter notification display, unread state, live delivery, replay, and push by origin. Preserve forwarding to the originating desktop's locally paired phones.

## Why

CLI create paths still broadcast activation, while shared status can cause unrelated viewers to generate notifications. Attribution belongs to the initiating run rather than the workspace creator, since different clients can start work in the same workspace. This extends existing identities and persistence instead of adding an ownership registry.

## Linked Issue

Related: #11027 (multi-client navigation isolation).

## Visual Proof

Pending before/after recording. Real background Electron validation passed with a server and two independently paired browser clients; a launch-only screenshot is not presented as behavioral proof. Keeping this PR in draft until the required visual evidence is attached.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated
- Final consolidated regression run: **101 tests across 11 files passed**, covering two-client activation, current/legacy CLI payloads, native child origin, SSH provisioning, origin retention, notification display/unread, replay, push, and renderer focus intent.
- `ORCA_BACKGROUND_LAUNCH=1 pnpm run test:e2e:multi-client-navigation`: **4/4 passed** on macOS with a real Electron server and two paired web clients. This run preceded the final bounded SSH/native/unread fixes; focused tests cover those fixes.
- Additional persistence, daemon, structured-session, launch, and restore tests passed during implementation. After the final file-size cleanup, all typecheck projects and 130 affected tests across 8 files passed; commit-hook lint, React Doctor and formatting also passed.
- Node, web, and CLI typechecks; changed-code quality; RPC params catalog; reliability gates; max-lines ratchet; and `git diff --check` passed.
- Physical Windows/Linux, live SSH, and actual `orca serve` bootstrap were not exercised. SSH and headless behavior have provider/service coverage.

## Review

Astra reviewed the concrete plan before implementation and reviewed the final fixes. All identified blockers were resolved.

## Agent skill upstream boundary

- [x] Not applicable: no upstream skill implementation copied.

## Notes

Wire changes use optional fields, with no new stream opcode. New clients connected to old hosts suppress unattributed ambient activation and unknown remote alerts while retaining explicit local navigation. Old clients connected to new hosts receive server-filtered events, but an old desktop can still derive teammate notifications locally; full notification isolation requires updating that desktop. Old/old behavior is unchanged.

Phones directly paired to the shared server receive their own attributed work; this does not infer a relationship to another desktop. No new headless completion producer is introduced.

## Checklist

- [ ] This PR is small and focused (one behavior change with plumbing across runtime boundaries)
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full lint/test/build matrix passes (affected checks passed locally; CI covers broader checks)
