### PR TITLE
feat(linear): accept current, previous, next and cycle numbers in list-issues --cycle

### DIFF
--- a/src/cli/specs/linear-mcp.ts
+++ b/src/cli/specs/linear-mcp.ts
@@ -43,7 +43,7 @@ export const LINEAR_MCP_COMMAND_SPECS: CommandSpec[] = [
     path: ['linear', 'list-issues'],
     summary: 'List Linear issues with MCP-compatible filters',
     usage:
-      'orca linear list-issues [--team <team>] [--cycle <cycle>] [--label <label>] [--limit <n>] [--query <text>] [--state <state>] [--cursor <cursor>] [--order-by createdAt|updatedAt] [--project <project>] [--release <release>] [--assignee <user|me|null>] [--delegate <user|me|null>] [--parent-id <issue|null>] [--priority <0-4>] [--created-at <datetime|duration>] [--updated-at <datetime|duration>] [--include-archived] [--workspace <id>|all] [--json]',
+      'orca linear list-issues [--team <team>] [--cycle <cycle|current|previous|next|number|null>] [--label <label>] [--limit <n>] [--query <text>] [--state <state>] [--cursor <cursor>] [--order-by createdAt|updatedAt] [--project <project>] [--release <release>] [--assignee <user|me|null>] [--delegate <user|me|null>] [--parent-id <issue|null>] [--priority <0-4>] [--created-at <datetime|duration>] [--updated-at <datetime|duration>] [--include-archived] [--workspace <id>|all] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'team',
@@ -75,7 +75,8 @@ export const LINEAR_MCP_COMMAND_SPECS: CommandSpec[] = [
       'Omitting --limit returns every match (result.meta.limit is null); --limit <n> caps the read.',
       'JSON sets result.truncated when a cap held results back; text prints truncated: showing N.',
       'Reuse --cursor from the previous page. Issued cursors bind the workspace; raw Linear cursors still need --workspace.',
-      '--priority is 0=none, 1=urgent, 2=high, 3=medium, 4=low. JSON includes priorityLabel on each issue.'
+      '--priority is 0=none, 1=urgent, 2=high, 3=medium, 4=low. JSON includes priorityLabel on each issue.',
+      '--cycle accepts a cycle id or name, current (alias active), previous, next, a cycle number, or null for issues without a cycle.'
     ]
   },
   {

--- a/src/main/linear/mcp-issue-list-filter.test.ts
+++ b/src/main/linear/mcp-issue-list-filter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { buildIssueFilter } from './mcp-issue-list-filter'
+
+const CYCLE_ID = '89f28b14-0eaa-4364-bfbb-d860ab46178f'
+
+describe('buildIssueFilter cycle', () => {
+  it('maps current and active to the active cycle', () => {
+    expect(buildIssueFilter({ cycle: 'current' })).toEqual({
+      cycle: { isActive: { eq: true } }
+    })
+    expect(buildIssueFilter({ cycle: 'active' })).toEqual({
+      cycle: { isActive: { eq: true } }
+    })
+  })
+
+  it('maps previous and next to the neighbouring cycles', () => {
+    expect(buildIssueFilter({ cycle: 'previous' })).toEqual({
+      cycle: { isPrevious: { eq: true } }
+    })
+    expect(buildIssueFilter({ cycle: 'next' })).toEqual({
+      cycle: { isNext: { eq: true } }
+    })
+  })
+
+  it('matches keywords regardless of letter case', () => {
+    expect(buildIssueFilter({ cycle: 'Current' })).toEqual({
+      cycle: { isActive: { eq: true } }
+    })
+    expect(buildIssueFilter({ cycle: 'NEXT' })).toEqual({
+      cycle: { isNext: { eq: true } }
+    })
+  })
+
+  it('maps a digits-only value to the cycle number', () => {
+    expect(buildIssueFilter({ cycle: '20' })).toEqual({
+      cycle: { number: { eq: 20 } }
+    })
+  })
+
+  it('keeps null selecting issues without a cycle', () => {
+    expect(buildIssueFilter({ cycle: 'null' })).toEqual({ cycle: { null: true } })
+  })
+
+  it('keeps matching a cycle id or a custom cycle name', () => {
+    expect(buildIssueFilter({ cycle: CYCLE_ID })).toEqual({
+      cycle: { or: [{ id: { eq: CYCLE_ID } }, { name: { eqIgnoreCase: CYCLE_ID } }] }
+    })
+    expect(buildIssueFilter({ cycle: 'Sprint 20' })).toEqual({
+      cycle: { or: [{ name: { eqIgnoreCase: 'Sprint 20' } }] }
+    })
+  })
+
+  it('combines the cycle keyword with other facets', () => {
+    expect(buildIssueFilter({ cycle: 'current', team: 'ENG', assignee: 'me' })).toEqual({
+      team: { or: [{ name: { eqIgnoreCase: 'ENG' } }, { key: { eqIgnoreCase: 'ENG' } }] },
+      cycle: { isActive: { eq: true } },
+      assignee: { isMe: { eq: true } }
+    })
+  })
+})

--- a/src/main/linear/mcp-issue-list-filter.ts
+++ b/src/main/linear/mcp-issue-list-filter.ts
@@ -6,7 +6,7 @@ export function buildIssueFilter(request: LinearMcpIssueListRequest): Record<str
     filter.team = namedFilter(request.team, true)
   }
   if (request.cycle) {
-    filter.cycle = nullableNamedFilter(request.cycle)
+    filter.cycle = nullableCycleFilter(request.cycle)
   }
   if (request.label) {
     filter.labels = { some: namedFilter(request.label) }
@@ -55,8 +55,27 @@ function namedFilter(value: string, includeKey = false, includeVersion = false):
   }
 }
 
-function nullableNamedFilter(value: string): object {
-  return value === 'null' ? { null: true } : namedFilter(value)
+// Why: cycles usually have no name, only a number, so the named filter alone cannot reach
+// them. Linear's CycleFilter exposes isActive/isPrevious/isNext and number directly.
+const CYCLE_KEYWORD_FILTERS = new Map<string, object>([
+  ['current', { isActive: { eq: true } }],
+  ['active', { isActive: { eq: true } }],
+  ['previous', { isPrevious: { eq: true } }],
+  ['next', { isNext: { eq: true } }]
+])
+
+function nullableCycleFilter(value: string): object {
+  if (value === 'null') {
+    return { null: true }
+  }
+  const keyword = CYCLE_KEYWORD_FILTERS.get(value.toLocaleLowerCase())
+  if (keyword) {
+    return keyword
+  }
+  if (/^\d+$/.test(value)) {
+    return { number: { eq: Number(value) } }
+  }
+  return namedFilter(value)
 }
 
 function workflowStateFilter(value: string): object {

--- a/src/main/linear/mcp-issue-list.test.ts
+++ b/src/main/linear/mcp-issue-list.test.ts
@@ -137,6 +137,22 @@ describe('MCP-compatible Linear issue listing', () => {
     expect(result.meta.workspaceId).toBe('workspace-1')
   })
 
+  it('sends cycle keywords as Linear cycle comparators', async () => {
+    rawRequest.mockResolvedValue({
+      data: { issues: { nodes: [], pageInfo: { hasNextPage: false } } }
+    })
+    const { listMcpIssues } = await import('./mcp-issue-list')
+
+    await listMcpIssues({ cycle: 'current', team: 'ENG' })
+
+    expect(rawRequest.mock.calls[0]?.[1]).toMatchObject({
+      filter: {
+        cycle: { isActive: { eq: true } },
+        team: { or: expect.arrayContaining([{ key: { eqIgnoreCase: 'ENG' } }]) }
+      }
+    })
+  })
+
   it('uses UUID comparators only for values Linear accepts as IDs', async () => {
     rawRequest.mockResolvedValue({
       data: { issues: { nodes: [], pageInfo: { hasNextPage: false } } }

--- a/src/main/ssh/ssh-remote-linear-read-help.ts
+++ b/src/main/ssh/ssh-remote-linear-read-help.ts
@@ -103,7 +103,7 @@ Examples:
 
 const LINEAR_MCP_ISSUE_LIST_HELP = `orca linear list-issues
 
-Usage: orca linear list-issues [--team <team>] [--cycle <cycle>] [--label <label>] [--limit <n>] [--query <text>] [--state <state>] [--cursor <cursor>] [--order-by createdAt|updatedAt] [--project <project>] [--release <release>] [--assignee <user|me|null>] [--delegate <user|me|null>] [--parent-id <issue|null>] [--priority <0-4>] [--created-at <datetime|duration>] [--updated-at <datetime|duration>] [--include-archived] [--workspace <id>|all] [--json]
+Usage: orca linear list-issues [--team <team>] [--cycle <cycle|current|previous|next|number|null>] [--label <label>] [--limit <n>] [--query <text>] [--state <state>] [--cursor <cursor>] [--order-by createdAt|updatedAt] [--project <project>] [--release <release>] [--assignee <user|me|null>] [--delegate <user|me|null>] [--parent-id <issue|null>] [--priority <0-4>] [--created-at <datetime|duration>] [--updated-at <datetime|duration>] [--include-archived] [--workspace <id>|all] [--json]
 
 List Linear issues with MCP-compatible filters and cursor pagination`
 


### PR DESCRIPTION
## ELI5

Linear organises work in cycles, which are numbered sprints. Today `orca linear list-issues --cycle` only understands a cycle's UUID or a custom name. Most cycles have no name, and Orca gives no way to find the UUID, so `--cycle current`, `--cycle previous` and `--cycle 20` all return an empty list and report success. This PR makes those values work the way a person expects.

## What Changed

- `--cycle` now maps `current` (alias `active`), `previous`, `next` and a digits-only value to Linear's `isActive`, `isPrevious`, `isNext` and `number` cycle comparators. Keywords are case-insensitive.
- A UUID, a custom cycle name and the literal `null` keep their existing behaviour. An unmatched value falls through to the existing name match, like every other filter in the builder.
- The `list-issues` usage line and notes in the command spec, and the same usage line in the SSH remote help, list the accepted values.
- New unit tests for the filter builder, plus one end-to-end case in the MCP list test that asserts the keyword reaches the GraphQL filter variables.

Only the issue-filter builder and help text change. The request type, the GraphQL query, the pagination walk and the result shape are untouched.

## Why

Cycle filtering was effectively unusable from the CLI. The fields needed already exist on Linear's `CycleFilter`, so this is a mapping change, not a new API surface. The keyword approach mirrors how `--assignee me` is already handled in the same builder.

This completes #16081 / #16082 rather than overlapping them: that PR adds cycle discovery (`team cycles`) and assignment (`cycle set/clear`) and does not touch the list-issues filter.

## Linked Issue

Fixes #20411 (filter half). Related: #16081, #16082.

## Visual Proof

N/A. CLI-only change, no UI or interaction change.

## Testing

Tested on Linux (WSL2). Automated only; I did not run a dev build of the app against a live workspace.

- `pnpm test src/main/linear src/cli/handlers/linear.test.ts src/cli/linear-format.test.ts` (20 files, 161 tests) and the SSH Linear list-issues tests
- `pnpm typecheck:node`, `pnpm typecheck:cli`
- `pnpm run check:code-quality:changed`, `oxlint` and `oxfmt --check` on the changed files

Reviewer steps: `orca linear list-issues --cycle current --team <key> --json` should return the active cycle's issues; `--cycle 20` the issues of cycle 20; `--cycle null` issues without a cycle; a UUID as before.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Drafted with an AI coding assistant. Every change was reviewed, tested and verified by the author before submission.

## Review

- Cross-platform: pure string-to-object mapping, no OS, path or shell dependency.
- SSH / remote / local: the filter is built on the execution host as before; no RPC params, stream frames or result fields change. Only the remote help text string was updated to match the CLI spec.
- Agents and integrations: Linear only; uses fields already present on Linear's `CycleFilter`. No other provider is touched.
- Performance: no extra requests; the mapping runs once per list call.
- UI: not applicable.
- Security: keyword lookup uses a `Map`, so prototype keys cannot match; the numeric branch accepts digits only.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Without `--team`, `isActive` matches the active cycle of every team in the workspace, which is Linear's own semantics. Exposing the cycle number in the `list-issues` output (today `cycle.name` is `null` for unnamed cycles) is a separate follow-up.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


