### PR TITLE
fix(editor): stop the rich markdown editor from mangling dollar-heavy files

### DIFF
--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -26,6 +26,27 @@ function roundTripMarkdown(content: string): string {
   }
 }
 
+function countInlineMathNodes(content: string): number {
+  const codec = createRichMarkdownEditorCodec()
+  const editor = new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({ codec }),
+    content: encodeRawMarkdownHtmlForRichEditor(content, codec),
+    contentType: 'markdown'
+  })
+  try {
+    let count = 0
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === 'inlineMath') {
+        count += 1
+      }
+    })
+    return count
+  } finally {
+    editor.destroy()
+  }
+}
+
 function markdownAfterTextReplace(content: string, search: string, replacement: string): string {
   const codec = createRichMarkdownEditorCodec()
   const editor = new Editor({
@@ -338,6 +359,28 @@ describe('rich markdown round trip', () => {
       `<details class="orca-details" data-orca-toggle="${variant}" open>\n<summary></summary>\n\n\n\n</details>`
     )
     expect(slashCommandSelectionParent(commandId)).toBe('detailsSummary')
+  })
+
+  it('keeps backslash-escaped characters instead of dropping them on load', () => {
+    // Why: marked emits `escape` tokens that Tiptap's parser otherwise discards, deleting the character.
+    expect(roundTripMarkdown('cost was \\$1,200, rate 5\\*, file\\_name, see \\[note\\].\n')).toBe(
+      'cost was $1,200, rate 5*, file_name, see [note].'
+    )
+  })
+
+  it('keeps escaped dollars inside table cells', () => {
+    expect(roundTripMarkdown('| Item | Amount |\n|---|---|\n| Fee | \\$500 |\n')).toContain('$500')
+  })
+
+  it('keeps dollar amounts as text instead of inline math', () => {
+    const content = 'from $10 to $20, then (deficit −$509,542 by end-2020) entered 2021 at $0'
+    expect(countInlineMathNodes(content)).toBe(0)
+    expect(roundTripMarkdown(`${content}\n`)).toBe(content)
+  })
+
+  it('still parses inline math that touches its dollar signs', () => {
+    expect(countInlineMathNodes('Energy is $E = mc^2$ here, and $x_1$ too.')).toBe(2)
+    expect(roundTripMarkdown('Energy is $E = mc^2$ here.\n')).toBe('Energy is $E = mc^2$ here.')
   })
 
   it('preserves markdown tables', () => {

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -372,11 +372,35 @@ describe('rich markdown round trip', () => {
       '\\*\\*not bold\\*\\* and \\_not em\\_',
       '\\`not code\\` and \\~\\~not strike\\~\\~',
       'C:\\\\Program Files\\\\(x86)',
-      'shell \\$HOME\\$ var'
+      'shell \\$HOME\\$ var',
+      // Why: marks must stay continuous around an escape; consecutive escapes need one backslash each.
+      '**cost \\$5 total** and **\\$5 fee** and **bold \\$**',
+      '[a \\$ b](http://x) and *a \\_ b* and *\\*literal\\**',
+      '**\\*\\*not bold\\*\\*** inside bold'
     ].join('\n\n')
     const once = roundTripMarkdown(`${content}\n`)
     expect(once).toBe(content)
     expect(roundTripMarkdown(`${once}\n`)).toBe(content)
+  })
+
+  it('does not escape inside code marks and drops the backslash for entity-encoded characters', () => {
+    expect(roundTripMarkdown('a \\& b and \\< c\n')).toBe('a &amp; b and &lt; c')
+    // Why: a code span never contains an escape token, so an escaped mark can only reach code
+    // through editing; the serializer must then emit the literal character.
+    const codec = createRichMarkdownEditorCodec()
+    const editor = new Editor({
+      element: null,
+      extensions: createRichMarkdownExtensions({ codec }),
+      content: encodeRawMarkdownHtmlForRichEditor('cost \\$5\n', codec),
+      contentType: 'markdown'
+    })
+    try {
+      editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size - 1 })
+      editor.commands.setCode()
+      expect(editor.getMarkdown()).toBe('`cost $5`')
+    } finally {
+      editor.destroy()
+    }
   })
 
   it('keeps escaped dollars inside table cells', () => {

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -361,26 +361,50 @@ describe('rich markdown round trip', () => {
     expect(slashCommandSelectionParent(commandId)).toBe('detailsSummary')
   })
 
-  it('keeps backslash-escaped characters instead of dropping them on load', () => {
-    // Why: marked emits `escape` tokens that Tiptap's parser otherwise discards, deleting the character.
-    expect(roundTripMarkdown('cost was \\$1,200, rate 5\\*, file\\_name, see \\[note\\].\n')).toBe(
-      'cost was $1,200, rate 5*, file_name, see [note].'
-    )
+  it('round-trips backslash-escaped characters byte for byte', () => {
+    // Why: Tiptap's parser dropped marked's `escape` token (the character vanished on load), and its
+    // serializer never re-escapes, so a bare character would become syntax on the next open.
+    const content = [
+      'cost was \\$1,200, rate 5\\*, file\\_name, see \\[note\\](y).',
+      '\\# not a heading',
+      '1\\. not a list',
+      '\\- not a bullet',
+      '\\*\\*not bold\\*\\* and \\_not em\\_',
+      '\\`not code\\` and \\~\\~not strike\\~\\~',
+      'C:\\\\Program Files\\\\(x86)',
+      'shell \\$HOME\\$ var'
+    ].join('\n\n')
+    const once = roundTripMarkdown(`${content}\n`)
+    expect(once).toBe(content)
+    expect(roundTripMarkdown(`${once}\n`)).toBe(content)
   })
 
   it('keeps escaped dollars inside table cells', () => {
-    expect(roundTripMarkdown('| Item | Amount |\n|---|---|\n| Fee | \\$500 |\n')).toContain('$500')
+    expect(roundTripMarkdown('| Item | Amount |\n|---|---|\n| Fee | \\$500 |\n')).toContain(
+      '\\$500'
+    )
+  })
+
+  it('does not turn escaped dollars into inline math', () => {
+    expect(countInlineMathNodes('shell \\$HOME\\$ var and \\$x\\$ too')).toBe(0)
   })
 
   it('keeps dollar amounts as text instead of inline math', () => {
     const content = 'from $10 to $20, then (deficit −$509,542 by end-2020) entered 2021 at $0'
     expect(countInlineMathNodes(content)).toBe(0)
     expect(roundTripMarkdown(`${content}\n`)).toBe(content)
+    // Why: Pandoc boundaries — a space inside either `$` or a digit after the closing `$` means money.
+    for (const text of ['$x$2 apples', 'costs $ x$ here', 'costs $x $ here', '$5-$6 range']) {
+      expect(countInlineMathNodes(text)).toBe(0)
+    }
   })
 
   it('still parses inline math that touches its dollar signs', () => {
     expect(countInlineMathNodes('Energy is $E = mc^2$ here, and $x_1$ too.')).toBe(2)
     expect(roundTripMarkdown('Energy is $E = mc^2$ here.\n')).toBe('Energy is $E = mc^2$ here.')
+    // Why: a formula may wrap across a soft line break, and may end in a LaTeX line break.
+    expect(countInlineMathNodes('wrap $a +\nb$ end')).toBe(1)
+    expect(countInlineMathNodes('break $x\\\\$ end')).toBe(1)
   })
 
   it('preserves markdown tables', () => {

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -410,7 +410,25 @@ describe('rich markdown round trip', () => {
   })
 
   it('does not turn escaped dollars into inline math', () => {
-    expect(countInlineMathNodes('shell \\$HOME\\$ var and \\$x\\$ too')).toBe(0)
+    const content = 'shell \\$HOME\\$ var, \\$x\\$ too, and costs $5 to \\$x here'
+    expect(countInlineMathNodes(content)).toBe(0)
+    expect(roundTripMarkdown(`${content}\n`)).toBe(content)
+  })
+
+  it('keeps escaped characters as searchable text', () => {
+    const codec = createRichMarkdownEditorCodec()
+    const editor = new Editor({
+      element: null,
+      extensions: createRichMarkdownExtensions({ codec }),
+      content: encodeRawMarkdownHtmlForRichEditor('cost \\$1,200 and file\\_name\n', codec),
+      contentType: 'markdown'
+    })
+    try {
+      // Why: find/replace treats atoms as read-only, so escapes must stay ordinary text.
+      expect(editor.state.doc.textContent).toBe('cost $1,200 and file_name')
+    } finally {
+      editor.destroy()
+    }
   })
 
   it('keeps dollar amounts as text instead of inline math', () => {

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -472,6 +472,26 @@ describe('rich markdown round trip', () => {
     expect(roundTripMarkdown('text\n\n$$\nx^2\n$$\n')).toBe('text\n\n$$\nx^2\n$$')
   })
 
+  it('parses display math that is indented or holds an escaped dollar', () => {
+    for (const source of [
+      'text\n\n  $$\nx^2\n$$\n',
+      'text\n $$\nx^2\n$$\n',
+      'text\n\t$$\nx^2\n$$\n'
+    ]) {
+      expect(roundTripMarkdown(source)).toBe('text\n\n$$\nx^2\n$$')
+    }
+    expect(roundTripMarkdown('$$\n\\$5 + x\n$$\n')).toBe('$$\n\\$5 + x\n$$')
+  })
+
+  it('escapes pipes inside link and image attributes in table cells', () => {
+    const once = roundTripMarkdown(
+      '| a | b |\n|---|---|\n| ![x \\| y](img.png) | [c \\| d](http://e "f \\| g") |\n'
+    )
+    expect(once).toContain('![x \\| y](img.png)')
+    expect(once).toContain('[c \\| d](http://e "f \\| g")')
+    expect(roundTripMarkdown(`${once}\n`)).toBe(once)
+  })
+
   it('preserves markdown tables', () => {
     expect(roundTripMarkdown('| a | b |\n| - | - |\n| 1 | 2 |\n')).toContain('| a')
   })

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -449,6 +449,29 @@ describe('rich markdown round trip', () => {
     expect(countInlineMathNodes('break $x\\\\$ end')).toBe(1)
   })
 
+  it('escapes pipes inside table cells so the row keeps its columns', () => {
+    // Why: marked unescapes `\\|` per cell before inline lexing, so the source form must add it back.
+    const once = roundTripMarkdown('| a \\| b | c |\n|---|---|\n| x \\| y | `p \\| q` |\n')
+    expect(once).toContain('a \\| b')
+    expect(once).toContain('x \\| y')
+    expect(once).toContain('`p \\| q`')
+    expect(roundTripMarkdown(`${once}\n`)).toBe(once)
+  })
+
+  it('keeps parentheses in link and image destinations escaped', () => {
+    expect(roundTripMarkdown('[a](b\\)c) and ![g](h\\(1\\).png)\n')).toBe(
+      '[a](b\\)c) and ![g](h\\(1\\).png)'
+    )
+    expect(roundTripMarkdown('[a](x "say \\"hi\\"")\n')).toBe('[a](x "say \\"hi\\"")')
+    expect(roundTripMarkdown('![a \\] b](x.png)\n')).toBe('![a \\] b](x.png)')
+  })
+
+  it('does not split a paragraph at a mid-line $$', () => {
+    const content = 'costs $$ big money $$ here, honestly'
+    expect(roundTripMarkdown(`${content}\n`)).toBe(content)
+    expect(roundTripMarkdown('text\n\n$$\nx^2\n$$\n')).toBe('text\n\n$$\nx^2\n$$')
+  })
+
   it('preserves markdown tables', () => {
     expect(roundTripMarkdown('| a | b |\n| - | - |\n| 1 | 2 |\n')).toContain('| a')
   })

--- a/src/renderer/src/components/editor/rich-markdown-escaped-character.ts
+++ b/src/renderer/src/components/editor/rich-markdown-escaped-character.ts
@@ -1,27 +1,28 @@
-import { Mark, type JSONContent } from '@tiptap/core'
+import { Mark } from '@tiptap/core'
 
 // marked's GFM inline escape rule: a backslash before ASCII punctuation.
 const ESCAPABLE_CHARACTER_PATTERN = /[!"#$%&'()*+,\-./:;<=>?@[\]\\^_`{|}~]/
 const ESCAPED_CHARACTER_PATTERN = /^\\([!"#$%&'()*+,\-./:;<=>?@[\]\\^_`{|}~])/
 // Why: the serializer entity-encodes these itself; a backslash in front would survive as literal text.
 const ENTITY_ENCODED_CHARACTERS = new Set(['&', '<', '>'])
-const MARK_NAME = 'richMarkdownEscapedCharacter'
 const MARKER_ATTRIBUTE = 'data-rich-markdown-escaped-character'
+
+export const RICH_MARKDOWN_ESCAPED_CHARACTER_MARK = 'richMarkdownEscapedCharacter'
 
 /**
  * Text that was backslash-escaped in the source. Tiptap's markdown parser has no
  * handler for marked's `escape` token (the character was deleted on load) and its
  * text serializer never re-escapes, so the mark carries the escape through the
- * document and `getMarkdown` writes it back per character (see below).
+ * document and the serializer-fidelity pass writes it back per character.
  */
 export const RichMarkdownEscapedCharacter = Mark.create({
-  name: MARK_NAME,
+  name: RICH_MARKDOWN_ESCAPED_CHARACTER_MARK,
   inclusive: false,
   keepOnSplit: false,
 
-  markdownTokenName: MARK_NAME,
+  markdownTokenName: RICH_MARKDOWN_ESCAPED_CHARACTER_MARK,
   markdownTokenizer: {
-    name: MARK_NAME,
+    name: RICH_MARKDOWN_ESCAPED_CHARACTER_MARK,
     level: 'inline',
     start: (src: string) => src.indexOf('\\'),
     tokenize(src: string) {
@@ -29,15 +30,17 @@ export const RichMarkdownEscapedCharacter = Mark.create({
       if (!match) {
         return undefined
       }
-      return { type: MARK_NAME, raw: match[0], character: match[1] }
+      return { type: RICH_MARKDOWN_ESCAPED_CHARACTER_MARK, raw: match[0], character: match[1] }
     }
   },
   parseMarkdown: (token, helpers) => {
     const character = (token as { character?: string }).character
-    if (token.type !== MARK_NAME || !character) {
+    if (token.type !== RICH_MARKDOWN_ESCAPED_CHARACTER_MARK || !character) {
       return []
     }
-    return helpers.applyMark(MARK_NAME, [{ type: 'text', text: character }])
+    return helpers.applyMark(RICH_MARKDOWN_ESCAPED_CHARACTER_MARK, [
+      { type: 'text', text: character }
+    ])
   },
   // Why: a mark's markdown is one prefix for the whole run, so `\*\*` would come out as `\**`;
   // this is only the fallback for a serializer that bypasses getMarkdown.
@@ -48,40 +51,19 @@ export const RichMarkdownEscapedCharacter = Mark.create({
   },
   renderHTML() {
     return ['span', { [MARKER_ATTRIBUTE]: '' }, 0]
-  },
-
-  onBeforeCreate() {
-    // Why: must be registered after `Markdown`, whose onBeforeCreate installs the
-    // getMarkdown this replaces; the manager itself is what serializes.
-    const editor = this.editor
-    editor.getMarkdown = () => {
-      const manager = editor.markdown
-      if (!manager) {
-        throw new Error('RichMarkdownEscapedCharacter requires the Markdown extension')
-      }
-      return manager.serialize(escapeMarkedCharacters(editor.getJSON()) as JSONContent)
-    }
   }
 })
 
-/** Turns escaped-mark text back into `\X` per character so mark runs around it stay continuous. */
-function escapeMarkedCharacters(node: JSONContent): JSONContent {
-  if (node.type === 'text' && node.marks?.some((mark) => mark.type === MARK_NAME)) {
-    const marks = node.marks.filter((mark) => mark.type !== MARK_NAME)
-    const insideCode = marks.some((mark) => mark.type === 'code')
-    const text = insideCode
-      ? (node.text ?? '')
-      : Array.from(node.text ?? '')
-          .map((character) =>
-            ESCAPABLE_CHARACTER_PATTERN.test(character) && !ENTITY_ENCODED_CHARACTERS.has(character)
-              ? `\\${character}`
-              : character
-          )
-          .join('')
-    return marks.length > 0 ? { ...node, text, marks } : { type: 'text', text }
+/** The source form of escaped-mark text: `\X` per escapable character, bare inside code. */
+export function escapedCharacterSourceText(text: string, insideCode: boolean): string {
+  if (insideCode) {
+    return text
   }
-  if (!node.content) {
-    return node
-  }
-  return { ...node, content: node.content.map(escapeMarkedCharacters) }
+  return Array.from(text)
+    .map((character) =>
+      ESCAPABLE_CHARACTER_PATTERN.test(character) && !ENTITY_ENCODED_CHARACTERS.has(character)
+        ? `\\${character}`
+        : character
+    )
+    .join('')
 }

--- a/src/renderer/src/components/editor/rich-markdown-escaped-character.ts
+++ b/src/renderer/src/components/editor/rich-markdown-escaped-character.ts
@@ -1,0 +1,67 @@
+import { Node } from '@tiptap/core'
+
+// marked's GFM inline escape rule: a backslash before ASCII punctuation.
+const ESCAPED_CHARACTER_PATTERN = /^\\([!"#$%&'()*+,\-./:;<=>?@[\]\\^_`{|}~])/
+const NODE_NAME = 'richMarkdownEscapedCharacter'
+const MARKER_ATTRIBUTE = 'data-rich-markdown-escaped-character'
+
+/**
+ * One inline atom per backslash-escaped character. Tiptap's markdown parser has
+ * no handler for marked's `escape` token (the character was deleted on load),
+ * and its text serializer never re-escapes, so a text node could not carry the
+ * backslash back to disk. An atom that owns the token round-trips `\$` as `\$`.
+ */
+export const RichMarkdownEscapedCharacter = Node.create({
+  name: NODE_NAME,
+  inline: true,
+  group: 'inline',
+  atom: true,
+  // Why: reads as one character of text; a node selection on click would be noise.
+  selectable: false,
+
+  addAttributes() {
+    return {
+      character: { default: '', rendered: false }
+    }
+  },
+
+  markdownTokenName: NODE_NAME,
+  markdownTokenizer: {
+    name: NODE_NAME,
+    level: 'inline',
+    start: (src: string) => src.indexOf('\\'),
+    tokenize(src: string) {
+      const match = src.match(ESCAPED_CHARACTER_PATTERN)
+      if (!match) {
+        return undefined
+      }
+      return { type: NODE_NAME, raw: match[0], character: match[1] }
+    }
+  },
+  parseMarkdown: (token, helpers) => {
+    const character = (token as { character?: string }).character
+    if (token.type !== NODE_NAME || !character) {
+      return []
+    }
+    return helpers.createNode(NODE_NAME, { character })
+  },
+  renderMarkdown: (node) => `\\${String(node.attrs?.character ?? '')}`,
+  renderText: ({ node }) => String(node.attrs.character ?? ''),
+
+  parseHTML() {
+    return [
+      {
+        tag: `span[${MARKER_ATTRIBUTE}]`,
+        getAttrs: (element: HTMLElement) => {
+          const character = element.getAttribute(MARKER_ATTRIBUTE) ?? ''
+          return ESCAPED_CHARACTER_PATTERN.test(`\\${character}`) ? { character } : false
+        }
+      }
+    ]
+  },
+
+  renderHTML({ node }) {
+    const character = String(node.attrs.character ?? '')
+    return ['span', { [MARKER_ATTRIBUTE]: character }, character]
+  }
+})

--- a/src/renderer/src/components/editor/rich-markdown-escaped-character.ts
+++ b/src/renderer/src/components/editor/rich-markdown-escaped-character.ts
@@ -1,33 +1,27 @@
-import { Node } from '@tiptap/core'
+import { Mark, type JSONContent } from '@tiptap/core'
 
 // marked's GFM inline escape rule: a backslash before ASCII punctuation.
+const ESCAPABLE_CHARACTER_PATTERN = /[!"#$%&'()*+,\-./:;<=>?@[\]\\^_`{|}~]/
 const ESCAPED_CHARACTER_PATTERN = /^\\([!"#$%&'()*+,\-./:;<=>?@[\]\\^_`{|}~])/
-const NODE_NAME = 'richMarkdownEscapedCharacter'
+// Why: the serializer entity-encodes these itself; a backslash in front would survive as literal text.
+const ENTITY_ENCODED_CHARACTERS = new Set(['&', '<', '>'])
+const MARK_NAME = 'richMarkdownEscapedCharacter'
 const MARKER_ATTRIBUTE = 'data-rich-markdown-escaped-character'
 
 /**
- * One inline atom per backslash-escaped character. Tiptap's markdown parser has
- * no handler for marked's `escape` token (the character was deleted on load),
- * and its text serializer never re-escapes, so a text node could not carry the
- * backslash back to disk. An atom that owns the token round-trips `\$` as `\$`.
+ * Text that was backslash-escaped in the source. Tiptap's markdown parser has no
+ * handler for marked's `escape` token (the character was deleted on load) and its
+ * text serializer never re-escapes, so the mark carries the escape through the
+ * document and `getMarkdown` writes it back per character (see below).
  */
-export const RichMarkdownEscapedCharacter = Node.create({
-  name: NODE_NAME,
-  inline: true,
-  group: 'inline',
-  atom: true,
-  // Why: reads as one character of text; a node selection on click would be noise.
-  selectable: false,
+export const RichMarkdownEscapedCharacter = Mark.create({
+  name: MARK_NAME,
+  inclusive: false,
+  keepOnSplit: false,
 
-  addAttributes() {
-    return {
-      character: { default: '', rendered: false }
-    }
-  },
-
-  markdownTokenName: NODE_NAME,
+  markdownTokenName: MARK_NAME,
   markdownTokenizer: {
-    name: NODE_NAME,
+    name: MARK_NAME,
     level: 'inline',
     start: (src: string) => src.indexOf('\\'),
     tokenize(src: string) {
@@ -35,33 +29,59 @@ export const RichMarkdownEscapedCharacter = Node.create({
       if (!match) {
         return undefined
       }
-      return { type: NODE_NAME, raw: match[0], character: match[1] }
+      return { type: MARK_NAME, raw: match[0], character: match[1] }
     }
   },
   parseMarkdown: (token, helpers) => {
     const character = (token as { character?: string }).character
-    if (token.type !== NODE_NAME || !character) {
+    if (token.type !== MARK_NAME || !character) {
       return []
     }
-    return helpers.createNode(NODE_NAME, { character })
+    return helpers.applyMark(MARK_NAME, [{ type: 'text', text: character }])
   },
-  renderMarkdown: (node) => `\\${String(node.attrs?.character ?? '')}`,
-  renderText: ({ node }) => String(node.attrs.character ?? ''),
+  // Why: a mark's markdown is one prefix for the whole run, so `\*\*` would come out as `\**`;
+  // this is only the fallback for a serializer that bypasses getMarkdown.
+  renderMarkdown: (node, helpers) => `\\${helpers.renderChildren(node)}`,
 
   parseHTML() {
-    return [
-      {
-        tag: `span[${MARKER_ATTRIBUTE}]`,
-        getAttrs: (element: HTMLElement) => {
-          const character = element.getAttribute(MARKER_ATTRIBUTE) ?? ''
-          return ESCAPED_CHARACTER_PATTERN.test(`\\${character}`) ? { character } : false
-        }
-      }
-    ]
+    return [{ tag: `span[${MARKER_ATTRIBUTE}]` }]
+  },
+  renderHTML() {
+    return ['span', { [MARKER_ATTRIBUTE]: '' }, 0]
   },
 
-  renderHTML({ node }) {
-    const character = String(node.attrs.character ?? '')
-    return ['span', { [MARKER_ATTRIBUTE]: character }, character]
+  onBeforeCreate() {
+    // Why: must be registered after `Markdown`, whose onBeforeCreate installs the
+    // getMarkdown this replaces; the manager itself is what serializes.
+    const editor = this.editor
+    editor.getMarkdown = () => {
+      const manager = editor.markdown
+      if (!manager) {
+        throw new Error('RichMarkdownEscapedCharacter requires the Markdown extension')
+      }
+      return manager.serialize(escapeMarkedCharacters(editor.getJSON()) as JSONContent)
+    }
   }
 })
+
+/** Turns escaped-mark text back into `\X` per character so mark runs around it stay continuous. */
+function escapeMarkedCharacters(node: JSONContent): JSONContent {
+  if (node.type === 'text' && node.marks?.some((mark) => mark.type === MARK_NAME)) {
+    const marks = node.marks.filter((mark) => mark.type !== MARK_NAME)
+    const insideCode = marks.some((mark) => mark.type === 'code')
+    const text = insideCode
+      ? (node.text ?? '')
+      : Array.from(node.text ?? '')
+          .map((character) =>
+            ESCAPABLE_CHARACTER_PATTERN.test(character) && !ENTITY_ENCODED_CHARACTERS.has(character)
+              ? `\\${character}`
+              : character
+          )
+          .join('')
+    return marks.length > 0 ? { ...node, text, marks } : { type: 'text', text }
+  }
+  if (!node.content) {
+    return node
+  }
+  return { ...node, content: node.content.map(escapeMarkedCharacters) }
+}

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -50,6 +50,27 @@ const RichMarkdownLink = Link.extend({
   priority: 90
 })
 
+// Why: upstream treats any same-line `$…$` pair as LaTeX, so "from $10 to $20" or
+// "at $0" became math atoms that also trim the text between the signs. Pandoc's
+// rule keeps money as text: both `$` must touch the formula and the closing one
+// must not be followed by a digit.
+const INLINE_MATH_PATTERN = /^\$(?![\s$])([^$\n]*?[^\s$\\])\$(?!\d)/
+
+const RichMarkdownInlineMath = InlineMath.extend({
+  markdownTokenizer: {
+    name: 'inlineMath',
+    level: 'inline',
+    start: (src: string) => src.indexOf('$'),
+    tokenize: (src: string) => {
+      const match = src.match(INLINE_MATH_PATTERN)
+      if (!match) {
+        return undefined
+      }
+      return { type: 'inlineMath', raw: match[0], latex: match[1].trim() }
+    }
+  }
+})
+
 const RichMarkdownCode = Code.extend({
   // Why: Markdown supports linked code labels, so code cannot exclude the link
   // mark even though it should still stay exclusive with emphasis marks.
@@ -230,7 +251,7 @@ export function createRichMarkdownExtensions({
     TableRow,
     TableHeader,
     TableCell,
-    InlineMath.configure({
+    RichMarkdownInlineMath.configure({
       katexOptions: {
         throwOnError: false
       }

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -39,6 +39,7 @@ import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-htm
 import { RichMarkdownOrderedList } from './rich-markdown-ordered-list'
 import { RichMarkdownParagraph } from './rich-markdown-paragraph'
 import { RichMarkdownCodeBlockLowlight } from './rich-markdown-lowlight'
+import { RichMarkdownEscapedCharacter } from './rich-markdown-escaped-character'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
 import { createCachedLowlight } from './rich-markdown-lowlight-cache'
 
@@ -50,11 +51,9 @@ const RichMarkdownLink = Link.extend({
   priority: 90
 })
 
-// Why: upstream treats any same-line `$…$` pair as LaTeX, so "from $10 to $20" or
-// "at $0" became math atoms that also trim the text between the signs. Pandoc's
-// rule keeps money as text: both `$` must touch the formula and the closing one
-// must not be followed by a digit.
-const INLINE_MATH_PATTERN = /^\$(?![\s$])([^$\n]*?[^\s$\\])\$(?!\d)/
+// Why: Pandoc's rule keeps money as text — both `$` must touch the formula and the
+// closing one must not be followed by a digit — where upstream turned "$10 to $20" into math.
+const INLINE_MATH_PATTERN = /^\$(?![\s$])([^$]*?[^\s$])\$(?!\d)/
 
 const RichMarkdownInlineMath = InlineMath.extend({
   markdownTokenizer: {
@@ -66,7 +65,7 @@ const RichMarkdownInlineMath = InlineMath.extend({
       if (!match) {
         return undefined
       }
-      return { type: 'inlineMath', raw: match[0], latex: match[1].trim() }
+      return { type: 'inlineMath', raw: match[0], latex: match[1] }
     }
   }
 })
@@ -262,6 +261,7 @@ export function createRichMarkdownExtensions({
         throwOnError: false
       }
     }),
+    RichMarkdownEscapedCharacter,
     createRichMarkdownLiteral(codec.transport),
     ...(htmlSuperscriptLinks
       ? [createRichMarkdownHtmlSuperscriptLink(codec.transport, htmlSuperscriptLinkContext!)]

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -40,6 +40,7 @@ import { RichMarkdownOrderedList } from './rich-markdown-ordered-list'
 import { RichMarkdownParagraph } from './rich-markdown-paragraph'
 import { RichMarkdownCodeBlockLowlight } from './rich-markdown-lowlight'
 import { RichMarkdownEscapedCharacter } from './rich-markdown-escaped-character'
+import { RichMarkdownSerializerFidelity } from './rich-markdown-serializer-fidelity'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
 import { createCachedLowlight } from './rich-markdown-lowlight-cache'
 
@@ -67,6 +68,26 @@ const RichMarkdownInlineMath = InlineMath.extend({
         return undefined
       }
       return { type: 'inlineMath', raw: match[0], latex: match[1] }
+    }
+  }
+})
+
+// Why: marked ends a paragraph wherever a block tokenizer's `start` points, so upstream's
+// `indexOf('$$')` split prose at a mid-line `$$`; display math only opens at a line start.
+const RichMarkdownBlockMath = BlockMath.extend({
+  markdownTokenizer: {
+    name: 'blockMath',
+    level: 'block',
+    start: (src: string) => {
+      const index = src.indexOf('\n$$')
+      return index === -1 ? -1 : index + 1
+    },
+    tokenize: (src: string) => {
+      const match = src.match(/^\$\$([^$]+)\$\$/)
+      if (!match) {
+        return undefined
+      }
+      return { type: 'blockMath', raw: match[0], latex: match[1].trim() }
     }
   }
 })
@@ -256,12 +277,13 @@ export function createRichMarkdownExtensions({
         throwOnError: false
       }
     }),
-    BlockMath.configure({
+    RichMarkdownBlockMath.configure({
       katexOptions: {
         displayMode: true,
         throwOnError: false
       }
     }),
+    RichMarkdownEscapedCharacter,
     createRichMarkdownLiteral(codec.transport),
     ...(htmlSuperscriptLinks
       ? [createRichMarkdownHtmlSuperscriptLink(codec.transport, htmlSuperscriptLinkContext!)]
@@ -277,7 +299,7 @@ export function createRichMarkdownExtensions({
       }
     }),
     // Why: wraps the getMarkdown that Markdown's onBeforeCreate installs, so it must follow it.
-    RichMarkdownEscapedCharacter,
+    RichMarkdownSerializerFidelity,
     createRichMarkdownAnnotationHighlightExtension()
   ]
 

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -261,7 +261,6 @@ export function createRichMarkdownExtensions({
         throwOnError: false
       }
     }),
-    RichMarkdownEscapedCharacter,
     createRichMarkdownLiteral(codec.transport),
     ...(htmlSuperscriptLinks
       ? [createRichMarkdownHtmlSuperscriptLink(codec.transport, htmlSuperscriptLinkContext!)]
@@ -276,6 +275,8 @@ export function createRichMarkdownExtensions({
         gfm: true
       }
     }),
+    // Why: wraps the getMarkdown that Markdown's onBeforeCreate installs, so it must follow it.
+    RichMarkdownEscapedCharacter,
     createRichMarkdownAnnotationHighlightExtension()
   ]
 

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -73,17 +73,20 @@ const RichMarkdownInlineMath = InlineMath.extend({
 })
 
 // Why: marked ends a paragraph wherever a block tokenizer's `start` points, so upstream's
-// `indexOf('$$')` split prose at a mid-line `$$`; display math only opens at a line start.
+// `indexOf('$$')` split prose at a mid-line `$$`; display math only opens at a (possibly
+// indented) line start, and its body may hold `\$` where upstream's `[^$]+` refused it.
+const BLOCK_MATH_START_PATTERN = /\n[ \t]*\$\$/
+const BLOCK_MATH_PATTERN = /^[ \t]*\$\$((?:(?!\$\$)[\s\S])+?)\$\$/
+
 const RichMarkdownBlockMath = BlockMath.extend({
   markdownTokenizer: {
     name: 'blockMath',
     level: 'block',
-    start: (src: string) => {
-      const index = src.indexOf('\n$$')
-      return index === -1 ? -1 : index + 1
-    },
+    // Why: marked cuts the paragraph at the returned index + 1; pointing at the newline keeps
+    // the indent out of the paragraph and lets the block tokenizer see the whole opener line.
+    start: (src: string) => BLOCK_MATH_START_PATTERN.exec(src)?.index ?? -1,
     tokenize: (src: string) => {
-      const match = src.match(/^\$\$([^$]+)\$\$/)
+      const match = src.match(BLOCK_MATH_PATTERN)
       if (!match) {
         return undefined
       }

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -51,9 +51,10 @@ const RichMarkdownLink = Link.extend({
   priority: 90
 })
 
-// Why: Pandoc's rule keeps money as text — both `$` must touch the formula and the
-// closing one must not be followed by a digit — where upstream turned "$10 to $20" into math.
-const INLINE_MATH_PATTERN = /^\$(?![\s$])([^$]*?[^\s$])\$(?!\d)/
+// Why: Pandoc's rule keeps money as text — both `$` must touch the formula, the closing one
+// must not be followed by a digit, and an escaped `\$` never closes — where upstream turned
+// "$10 to $20" into math.
+const INLINE_MATH_PATTERN = /^\$(?![\s$])((?:\\[\s\S]|[^$\\])*?)(?<!\s)\$(?!\d)/
 
 const RichMarkdownInlineMath = InlineMath.extend({
   markdownTokenizer: {

--- a/src/renderer/src/components/editor/rich-markdown-serializer-fidelity.ts
+++ b/src/renderer/src/components/editor/rich-markdown-serializer-fidelity.ts
@@ -1,0 +1,104 @@
+import { Extension, type JSONContent } from '@tiptap/core'
+import {
+  escapedCharacterSourceText,
+  RICH_MARKDOWN_ESCAPED_CHARACTER_MARK
+} from './rich-markdown-escaped-character'
+
+type SerializerContext = {
+  insideTableCell: boolean
+}
+
+/**
+ * Wraps `getMarkdown` so the document JSON is rewritten into its source form
+ * before Tiptap serializes it. Tiptap 3.22.5 writes text, link destinations and
+ * image alt text verbatim, which re-parses differently whenever they hold
+ * markdown syntax; each rule below is one such case the parser accepted.
+ */
+export const RichMarkdownSerializerFidelity = Extension.create({
+  name: 'richMarkdownSerializerFidelity',
+
+  onBeforeCreate() {
+    // Why: must be registered after `Markdown`, whose onBeforeCreate installs the
+    // getMarkdown this replaces; the manager itself is what serializes.
+    const editor = this.editor
+    editor.getMarkdown = () => {
+      const manager = editor.markdown
+      if (!manager) {
+        throw new Error('RichMarkdownSerializerFidelity requires the Markdown extension')
+      }
+      return manager.serialize(toSourceForm(editor.getJSON(), { insideTableCell: false }))
+    }
+  }
+})
+
+function toSourceForm(node: JSONContent, context: SerializerContext): JSONContent {
+  if (node.type === 'text') {
+    return textToSourceForm(node, context)
+  }
+  const next: JSONContent = node.type === 'image' ? imageToSourceForm(node) : node
+  if (!next.content) {
+    return next
+  }
+  const childContext =
+    node.type === 'tableCell' || node.type === 'tableHeader'
+      ? { ...context, insideTableCell: true }
+      : context
+  return { ...next, content: next.content.map((child) => toSourceForm(child, childContext)) }
+}
+
+function textToSourceForm(node: JSONContent, context: SerializerContext): JSONContent {
+  const marks = (node.marks ?? []).map(linkMarkToSourceForm)
+  const escaped = marks.some((mark) => mark.type === RICH_MARKDOWN_ESCAPED_CHARACTER_MARK)
+  const insideCode = marks.some((mark) => mark.type === 'code')
+  let text = node.text ?? ''
+  if (escaped) {
+    text = escapedCharacterSourceText(text, insideCode)
+  } else if (context.insideTableCell) {
+    // Why: marked splits cells on unescaped `|` before inline lexing, code spans included.
+    text = text.replace(/\|/g, '\\|')
+  }
+  const kept = marks.filter((mark) => mark.type !== RICH_MARKDOWN_ESCAPED_CHARACTER_MARK)
+  return kept.length > 0 ? { ...node, text, marks: kept } : { type: 'text', text }
+}
+
+function linkMarkToSourceForm(mark: NonNullable<JSONContent['marks']>[number]) {
+  if (mark.type !== 'link' || !mark.attrs) {
+    return mark
+  }
+  return {
+    ...mark,
+    attrs: {
+      ...mark.attrs,
+      href: destinationToSourceForm(mark.attrs.href),
+      title: titleToSourceForm(mark.attrs.title)
+    }
+  }
+}
+
+function imageToSourceForm(node: JSONContent): JSONContent {
+  if (!node.attrs) {
+    return node
+  }
+  return {
+    ...node,
+    attrs: {
+      ...node.attrs,
+      src: destinationToSourceForm(node.attrs.src),
+      alt:
+        typeof node.attrs.alt === 'string'
+          ? node.attrs.alt.replace(/[\\[\]]/g, '\\$&')
+          : node.attrs.alt,
+      title: titleToSourceForm(node.attrs.title)
+    }
+  }
+}
+
+// Why: a bare destination ends at an unbalanced `)`; marked unescapes `\(` and `\)` back on load.
+// (The `<…>` form is not an option here: Orca's raw-HTML pass would placeholder it before parsing.)
+function destinationToSourceForm(destination: unknown): unknown {
+  return typeof destination === 'string' ? destination.replace(/[()]/g, '\\$&') : destination
+}
+
+function titleToSourceForm(title: unknown): unknown {
+  return typeof title === 'string' ? title.replace(/"/g, '\\"') : title
+}

--- a/src/renderer/src/components/editor/rich-markdown-serializer-fidelity.ts
+++ b/src/renderer/src/components/editor/rich-markdown-serializer-fidelity.ts
@@ -35,7 +35,7 @@ function toSourceForm(node: JSONContent, context: SerializerContext): JSONConten
   if (node.type === 'text') {
     return textToSourceForm(node, context)
   }
-  const next: JSONContent = node.type === 'image' ? imageToSourceForm(node) : node
+  const next: JSONContent = node.type === 'image' ? imageToSourceForm(node, context) : node
   if (!next.content) {
     return next
   }
@@ -47,21 +47,20 @@ function toSourceForm(node: JSONContent, context: SerializerContext): JSONConten
 }
 
 function textToSourceForm(node: JSONContent, context: SerializerContext): JSONContent {
-  const marks = (node.marks ?? []).map(linkMarkToSourceForm)
+  const marks = (node.marks ?? []).map((mark) => linkMarkToSourceForm(mark, context))
   const escaped = marks.some((mark) => mark.type === RICH_MARKDOWN_ESCAPED_CHARACTER_MARK)
   const insideCode = marks.some((mark) => mark.type === 'code')
-  let text = node.text ?? ''
-  if (escaped) {
-    text = escapedCharacterSourceText(text, insideCode)
-  } else if (context.insideTableCell) {
-    // Why: marked splits cells on unescaped `|` before inline lexing, code spans included.
-    text = text.replace(/\|/g, '\\|')
-  }
+  const text = escaped
+    ? escapedCharacterSourceText(node.text ?? '', insideCode)
+    : escapeTableCellPipes(node.text ?? '', context)
   const kept = marks.filter((mark) => mark.type !== RICH_MARKDOWN_ESCAPED_CHARACTER_MARK)
   return kept.length > 0 ? { ...node, text, marks: kept } : { type: 'text', text }
 }
 
-function linkMarkToSourceForm(mark: NonNullable<JSONContent['marks']>[number]) {
+function linkMarkToSourceForm(
+  mark: NonNullable<JSONContent['marks']>[number],
+  context: SerializerContext
+) {
   if (mark.type !== 'link' || !mark.attrs) {
     return mark
   }
@@ -69,13 +68,13 @@ function linkMarkToSourceForm(mark: NonNullable<JSONContent['marks']>[number]) {
     ...mark,
     attrs: {
       ...mark.attrs,
-      href: destinationToSourceForm(mark.attrs.href),
-      title: titleToSourceForm(mark.attrs.title)
+      href: destinationToSourceForm(mark.attrs.href, context),
+      title: titleToSourceForm(mark.attrs.title, context)
     }
   }
 }
 
-function imageToSourceForm(node: JSONContent): JSONContent {
+function imageToSourceForm(node: JSONContent, context: SerializerContext): JSONContent {
   if (!node.attrs) {
     return node
   }
@@ -83,22 +82,31 @@ function imageToSourceForm(node: JSONContent): JSONContent {
     ...node,
     attrs: {
       ...node.attrs,
-      src: destinationToSourceForm(node.attrs.src),
+      src: destinationToSourceForm(node.attrs.src, context),
       alt:
         typeof node.attrs.alt === 'string'
-          ? node.attrs.alt.replace(/[\\[\]]/g, '\\$&')
+          ? escapeTableCellPipes(node.attrs.alt.replace(/[\\[\]]/g, '\\$&'), context)
           : node.attrs.alt,
-      title: titleToSourceForm(node.attrs.title)
+      title: titleToSourceForm(node.attrs.title, context)
     }
   }
 }
 
 // Why: a bare destination ends at an unbalanced `)`; marked unescapes `\(` and `\)` back on load.
 // (The `<…>` form is not an option here: Orca's raw-HTML pass would placeholder it before parsing.)
-function destinationToSourceForm(destination: unknown): unknown {
-  return typeof destination === 'string' ? destination.replace(/[()]/g, '\\$&') : destination
+function destinationToSourceForm(destination: unknown, context: SerializerContext): unknown {
+  return typeof destination === 'string'
+    ? escapeTableCellPipes(destination.replace(/[()]/g, '\\$&'), context)
+    : destination
 }
 
-function titleToSourceForm(title: unknown): unknown {
-  return typeof title === 'string' ? title.replace(/"/g, '\\"') : title
+function titleToSourceForm(title: unknown, context: SerializerContext): unknown {
+  return typeof title === 'string'
+    ? escapeTableCellPipes(title.replace(/"/g, '\\"'), context)
+    : title
+}
+
+// Why: marked splits cells on unescaped `|` before parsing anything inside them, attributes included.
+function escapeTableCellPipes(text: string, context: SerializerContext): string {
+  return context.insideTableCell ? text.replace(/\|/g, '\\|') : text
 }

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -400,6 +400,27 @@ describe('serializeRichMarkdownForReconcile (real editor pipeline)', () => {
   const serialize = (md: string): string | null =>
     serializeRichMarkdownForReconcile(md, serializerContext)
 
+  it('patches an edit at the end of a dollar-and-ampersand doc with the real serializer', () => {
+    // Why: the parser used to drop `\\$` and the serializer still writes `&amp;` and re-pads tables;
+    // an end-of-file edit must keep the untouched source bytes instead of canonicalizing the file.
+    const originalSource =
+      'Cost was \\$1,200 for Nell & Mary.\n\n| Item         | Amount |\n|--------------|-------:|\n| Fee          | \\$500  |\n\nTrailing paragraph.\n'
+    const baseCanonical = serialize(originalSource)!
+    expect(baseCanonical.endsWith('\n')).toBe(false) // getMarkdown never emits a trailing newline
+    const edited = `${baseCanonical} Added word.`
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: (md) => serialize(md)
+    })
+
+    expect(reconciled).toBe(
+      'Cost was \\$1,200 for Nell & Mary.\n\n| Item         | Amount |\n|--------------|-------:|\n| Fee          | \\$500  |\n\nTrailing paragraph. Added word.\n'
+    )
+  })
+
   it('applies normalizeEmptyListItems so empty list items round-trip stably', () => {
     // `3. ` immediately before a heading parses as an empty list item; without the
     // normalize step the safety re-parse would spuriously mismatch and no-op.
@@ -552,5 +573,58 @@ describe('serializeRichMarkdownForReconcile (real editor pipeline)', () => {
     })
 
     expect(serialize(reconciled)!.trimEnd()).toBe(edited.trimEnd())
+  })
+})
+
+describe('reconcileSerializedMarkdown end-of-document edits', () => {
+  // Why: real getMarkdown never emits a trailing newline; mimic that on both the base and the safety re-parse.
+  const canonicalWithoutTrailingNewline = (md: string): string =>
+    fakeCanonicalize(md).replace(/\n+$/, '')
+
+  it('patches an appended edit into a source that ends with a newline', () => {
+    const originalSource = '# Title\n\n_emphasis_ and __strong__\n\nTrailing paragraph.\n'
+    const baseCanonical = canonicalWithoutTrailingNewline(originalSource)
+    const edited = `${baseCanonical} Added word.`
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: canonicalWithoutTrailingNewline
+    })
+
+    expect(reconciled).toBe(
+      '# Title\n\n_emphasis_ and __strong__\n\nTrailing paragraph. Added word.\n'
+    )
+  })
+
+  it('patches an appended edit into a CRLF source that ends with a newline', () => {
+    const originalSource = '# Title\r\n\r\n_emphasis_\r\n\r\nTrailing paragraph.\r\n'
+    const baseCanonical = canonicalWithoutTrailingNewline(originalSource.replace(/\r\n/g, '\n'))
+    const edited = `${baseCanonical} Added word.`
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: canonicalWithoutTrailingNewline
+    })
+
+    expect(reconciled).toBe('# Title\r\n\r\n_emphasis_\r\n\r\nTrailing paragraph. Added word.\r\n')
+  })
+
+  it('still patches an edit at the end of a source without a trailing newline', () => {
+    const originalSource = '# Title\n\n_emphasis_\n\nTrailing paragraph.'
+    const baseCanonical = canonicalWithoutTrailingNewline(originalSource)
+    const edited = `${baseCanonical} Added word.`
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: canonicalWithoutTrailingNewline
+    })
+
+    expect(reconciled).toBe('# Title\n\n_emphasis_\n\nTrailing paragraph. Added word.')
   })
 })

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -406,7 +406,8 @@ describe('serializeRichMarkdownForReconcile (real editor pipeline)', () => {
     const originalSource =
       'Cost was \\$1,200 for Nell & Mary.\n\n| Item         | Amount |\n|--------------|-------:|\n| Fee          | \\$500  |\n\nTrailing paragraph.\n'
     const baseCanonical = serialize(originalSource)!
-    expect(baseCanonical.endsWith('\n')).toBe(false) // getMarkdown never emits a trailing newline
+    // getMarkdown has no trailing newline for a source that ends in a single newline
+    expect(baseCanonical.endsWith('\n')).toBe(false)
     const edited = `${baseCanonical} Added word.`
 
     const reconciled = reconcileSerializedMarkdown({
@@ -419,6 +420,39 @@ describe('serializeRichMarkdownForReconcile (real editor pipeline)', () => {
     expect(reconciled).toBe(
       'Cost was \\$1,200 for Nell & Mary.\n\n| Item         | Amount |\n|--------------|-------:|\n| Fee          | \\$500  |\n\nTrailing paragraph. Added word.\n'
     )
+  })
+
+  it('keeps source style when typing into a trailing empty paragraph (source ends in a blank line)', () => {
+    // Why: `text\n\n` parses to a trailing empty paragraph, so canonical ends in `\n\n` too; the
+    // end-of-file body strip must not run here or the whole file falls back to canonical.
+    const originalSource = 'Cost \\$1 for _em_.\n\ntext\n\n'
+    const baseCanonical = serialize(originalSource)!
+    expect(baseCanonical.endsWith('\n\n')).toBe(true)
+    const edited = `${baseCanonical}Added`
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: (md) => serialize(md)
+    })
+
+    expect(reconciled).toBe('Cost \\$1 for _em_.\n\ntext\n\nAdded')
+  })
+
+  it('keeps source style when deleting the trailing empty paragraph', () => {
+    const originalSource = 'Cost \\$1 for _em_.\n\ntext\n\n'
+    const baseCanonical = serialize(originalSource)!
+    const edited = baseCanonical.replace(/\n+$/, '') // Backspace at end of document
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: (md) => serialize(md)
+    })
+
+    expect(reconciled).toBe('Cost \\$1 for _em_.\n\ntext')
   })
 
   it('applies normalizeEmptyListItems so empty list items round-trip stably', () => {
@@ -611,6 +645,23 @@ describe('reconcileSerializedMarkdown end-of-document edits', () => {
     })
 
     expect(reconciled).toBe('# Title\r\n\r\n_emphasis_\r\n\r\nTrailing paragraph. Added word.\r\n')
+  })
+
+  it('keeps the source trailing newline when falling back to canonical output', () => {
+    // Branch 3 (oversize) is the simplest guaranteed fallback.
+    const body = '# Title\n\n_emphasis_\n\n'.repeat(4_000)
+    const originalSource = `${body}Trailing paragraph.\n`
+    const baseCanonical = canonicalWithoutTrailingNewline(originalSource)
+    const edited = `${baseCanonical} Added word.`
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: canonicalWithoutTrailingNewline
+    })
+
+    expect(reconciled).toBe(`${edited}\n`)
   })
 
   it('still patches an edit at the end of a source without a trailing newline', () => {

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -440,6 +440,23 @@ describe('serializeRichMarkdownForReconcile (real editor pipeline)', () => {
     expect(reconciled).toBe('Cost \\$1 for _em_.\n\ntext\n\nAdded')
   })
 
+  it('keeps source style when appending to a source whose last line is whitespace only', () => {
+    // Why: the trailing run is one newline, so the body strip is tried first; it lands after the
+    // spaces and fails the proof, and the whole-text patch must then take over instead of canonical.
+    const originalSource = 'Cost \\$1 & co.\n\nLast.\n  \n'
+    const baseCanonical = serialize(originalSource)!
+    const edited = `${baseCanonical} Added.`
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: (md) => serialize(md)
+    })
+
+    expect(reconciled).toBe('Cost \\$1 & co.\n\nLast. Added.\n  \n')
+  })
+
   it('keeps source style when deleting the trailing empty paragraph', () => {
     const originalSource = 'Cost \\$1 for _em_.\n\ntext\n\n'
     const baseCanonical = serialize(originalSource)!

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -74,11 +74,24 @@ export function reconcileSerializedMarkdown({
   }
 
   // Branch 4: run the divergent-base patch entirely in LF space.
+  // Why: getMarkdown emits no trailing newline while the source usually has one, so an end-of-document
+  // hunk (whose trailing context is dmp's end-of-text padding) lands after the source's newline, fails
+  // the branch-6 proof, and canonicalizes the whole file. Patch the bodies and re-attach the newline run.
+  const sourceTrailingNewlines = originalSourceLf.match(/\n+$/)?.[0] ?? ''
+  const baseTrailingNewlines = baseLf.match(/\n+$/)?.[0] ?? ''
+  const editedTrailingNewlines = editedLf.match(/\n+$/)?.[0] ?? ''
+  const sourceBody = stripTrailingNewlines(originalSourceLf)
+  const baseBody = stripTrailingNewlines(baseLf)
+  const editedBody = stripTrailingNewlines(editedLf)
+  // Same rule as branch 2: an edit that changes the trailing run is semantic and rides on top of the source's own run.
+  const reconciledTrailingNewlines =
+    (editedTrailingNewlines === baseTrailingNewlines ? '' : editedTrailingNewlines) +
+    sourceTrailingNewlines
   // Why: dmp's half-match accelerator ignores the diff deadline (100ms+ on repeated seeds), so bail to canonical for highly repetitive replacements.
-  if (hasRepeatedHalfMatchSeed(baseLf, editedLf)) {
+  if (hasRepeatedHalfMatchSeed(baseBody, editedBody)) {
     return restoreEol(editedLf, eol)
   }
-  let diffs = makeDiff(baseLf, editedLf, {
+  let diffs = makeDiff(baseBody, editedBody, {
     checkLines: true,
     timeout: RECONCILE_DIFF_TIMEOUT_SECONDS
   })
@@ -87,17 +100,18 @@ export function reconcileSerializedMarkdown({
     diffs = cleanupSemantic(diffs)
     diffs = cleanupEfficiency(diffs)
   }
-  const patches = makePatches(baseLf, diffs)
+  const patches = makePatches(baseBody, diffs)
   // Why: applyPatches decodes starts as UTF-8 offsets even though makePatches returns UTF-16 indices; encode against the divergent text being patched so decoding preserves the fuzzy-match seed.
   const utf8Offsets = getUtf8OffsetsAtCodeUnitIndices(
-    originalSourceLf,
+    sourceBody,
     patches.flatMap((patch) => [patch.start1, patch.start2])
   )
   for (const patch of patches) {
     patch.start1 = utf8Offsets.get(patch.start1) ?? 0
     patch.start2 = utf8Offsets.get(patch.start2) ?? 0
   }
-  const [reconciledLf, results] = applyPatches(patches, originalSourceLf)
+  const [reconciledBody, results] = applyPatches(patches, sourceBody)
+  const reconciledLf = reconciledBody + reconciledTrailingNewlines
 
   // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match, fall back to canonical.
   if (results.some((applied) => !applied)) {

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -30,6 +30,8 @@ export type ReconcileSerializedMarkdownParams = {
   roundTrip: (markdown: string) => string | null
 }
 
+type PatchAttempt = { source: string; base: string; edited: string; trailing: string }
+
 export function restoreMarkdownSourceEol(markdown: string, source: string): string {
   return restoreEol(toLf(markdown), detectDominantEol(source))
 }
@@ -82,24 +84,47 @@ export function reconcileSerializedMarkdown({
     return canonicalFallback()
   }
 
+  // Why: dmp's half-match accelerator ignores the diff deadline (100ms+ on repeated seeds), so bail to canonical for highly repetitive replacements.
+  if (hasRepeatedHalfMatchSeed(baseLf, editedLf)) {
+    return canonicalFallback()
+  }
+
   // Branch 4: run the divergent-base patch entirely in LF space.
   // Why: when the source ends in one newline that canonical lacks, an end-of-document hunk (whose
   // trailing context is dmp's end-of-text padding) lands after that newline and fails branch 6, so
-  // patch the bodies and re-attach the run. Any other shape (a trailing empty paragraph is `\n\n`
-  // in canonical too) patches correctly whole.
-  const editedTrailingNewlines = editedLf.match(/\n+$/)?.[0] ?? ''
-  const stripEnd = !baseLf.endsWith('\n') && originalTrailingNewlines.length === 1
-  const sourceBody = stripEnd ? stripTrailingNewlines(originalSourceLf) : originalSourceLf
-  const baseBody = baseLf
-  const editedBody = stripEnd ? stripTrailingNewlines(editedLf) : editedLf
-  const reconciledTrailingNewlines = stripEnd
-    ? editedTrailingNewlines + originalTrailingNewlines
-    : ''
-  // Why: dmp's half-match accelerator ignores the diff deadline (100ms+ on repeated seeds), so bail to canonical for highly repetitive replacements.
-  if (hasRepeatedHalfMatchSeed(baseBody, editedBody)) {
-    return canonicalFallback()
+  // try the bodies first and re-attach the run; the whole-text patch (right for every other shape)
+  // stays as the second attempt so no file does worse than before.
+  const attempts: PatchAttempt[] = []
+  if (!baseLf.endsWith('\n') && originalTrailingNewlines.length === 1) {
+    attempts.push({
+      source: stripTrailingNewlines(originalSourceLf),
+      base: baseLf,
+      edited: stripTrailingNewlines(editedLf),
+      trailing: (editedLf.match(/\n+$/)?.[0] ?? '') + originalTrailingNewlines
+    })
   }
-  let diffs = makeDiff(baseBody, editedBody, {
+  attempts.push({ source: originalSourceLf, base: baseLf, edited: editedLf, trailing: '' })
+
+  for (const attempt of attempts) {
+    // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match.
+    const patched = patchDivergentSource(attempt.source, attempt.base, attempt.edited)
+    if (patched === null) {
+      continue
+    }
+    const reconciledLf = patched + attempt.trailing
+    // Branch 6: prove reconciled bytes render-equal the editor's document — any fuzzy misplacement changes canonical output and is caught here.
+    const reparsed = roundTrip(reconciledLf)
+    if (reparsed !== null && normalizeForSafety(reparsed) === normalizeForSafety(editedLf)) {
+      // Restore the detected EOL as the final step so reconciled CRLF stays CRLF.
+      return restoreEol(reconciledLf, eol)
+    }
+  }
+  return canonicalFallback()
+}
+
+/** Applies the base→edited diff onto the divergent source; null when a hunk could not be located. */
+function patchDivergentSource(source: string, base: string, edited: string): string | null {
+  let diffs = makeDiff(base, edited, {
     checkLines: true,
     timeout: RECONCILE_DIFF_TIMEOUT_SECONDS
   })
@@ -108,32 +133,18 @@ export function reconcileSerializedMarkdown({
     diffs = cleanupSemantic(diffs)
     diffs = cleanupEfficiency(diffs)
   }
-  const patches = makePatches(baseBody, diffs)
+  const patches = makePatches(base, diffs)
   // Why: applyPatches decodes starts as UTF-8 offsets even though makePatches returns UTF-16 indices; encode against the divergent text being patched so decoding preserves the fuzzy-match seed.
   const utf8Offsets = getUtf8OffsetsAtCodeUnitIndices(
-    sourceBody,
+    source,
     patches.flatMap((patch) => [patch.start1, patch.start2])
   )
   for (const patch of patches) {
     patch.start1 = utf8Offsets.get(patch.start1) ?? 0
     patch.start2 = utf8Offsets.get(patch.start2) ?? 0
   }
-  const [reconciledBody, results] = applyPatches(patches, sourceBody)
-  const reconciledLf = reconciledBody + reconciledTrailingNewlines
-
-  // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match, fall back to canonical.
-  if (results.some((applied) => !applied)) {
-    return canonicalFallback()
-  }
-
-  // Branch 6: prove reconciled bytes render-equal the editor's document — any fuzzy misplacement changes canonical output and is caught here → canonical fallback.
-  const reparsed = roundTrip(reconciledLf)
-  if (reparsed === null || normalizeForSafety(reparsed) !== normalizeForSafety(editedLf)) {
-    return canonicalFallback()
-  }
-
-  // Restore the detected EOL as the final step so reconciled CRLF stays CRLF.
-  return restoreEol(reconciledLf, eol)
+  const [patched, results] = applyPatches(patches, source)
+  return results.some((applied) => !applied) ? null : patched
 }
 
 function stripTrailingNewlines(lfText: string): string {

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -65,31 +65,39 @@ export function reconcileSerializedMarkdown({
     return restoreEol(editedLf + originalTrailingNewlines, eol)
   }
 
+  // Why: canonical output has no final newline; keep the source's single one so a fallback does not strip it.
+  const canonicalFallback = (): string =>
+    restoreEol(
+      editedLf.endsWith('\n') || originalTrailingNewlines.length !== 1
+        ? editedLf
+        : editedLf + originalTrailingNewlines,
+      eol
+    )
+
   // Branch 3: oversize → bounded-cost canonical fallback (today's behavior).
   if (
     Math.max(originalSource.length, baseCanonical.length, edited.length) >
     RECONCILE_SIZE_CAP_CODE_UNITS
   ) {
-    return restoreEol(editedLf, eol)
+    return canonicalFallback()
   }
 
   // Branch 4: run the divergent-base patch entirely in LF space.
-  // Why: getMarkdown emits no trailing newline while the source usually has one, so an end-of-document
-  // hunk (whose trailing context is dmp's end-of-text padding) lands after the source's newline, fails
-  // the branch-6 proof, and canonicalizes the whole file. Patch the bodies and re-attach the newline run.
-  const sourceTrailingNewlines = originalSourceLf.match(/\n+$/)?.[0] ?? ''
-  const baseTrailingNewlines = baseLf.match(/\n+$/)?.[0] ?? ''
+  // Why: when the source ends in one newline that canonical lacks, an end-of-document hunk (whose
+  // trailing context is dmp's end-of-text padding) lands after that newline and fails branch 6, so
+  // patch the bodies and re-attach the run. Any other shape (a trailing empty paragraph is `\n\n`
+  // in canonical too) patches correctly whole.
   const editedTrailingNewlines = editedLf.match(/\n+$/)?.[0] ?? ''
-  const sourceBody = stripTrailingNewlines(originalSourceLf)
-  const baseBody = stripTrailingNewlines(baseLf)
-  const editedBody = stripTrailingNewlines(editedLf)
-  // Same rule as branch 2: an edit that changes the trailing run is semantic and rides on top of the source's own run.
-  const reconciledTrailingNewlines =
-    (editedTrailingNewlines === baseTrailingNewlines ? '' : editedTrailingNewlines) +
-    sourceTrailingNewlines
+  const stripEnd = !baseLf.endsWith('\n') && originalTrailingNewlines.length === 1
+  const sourceBody = stripEnd ? stripTrailingNewlines(originalSourceLf) : originalSourceLf
+  const baseBody = baseLf
+  const editedBody = stripEnd ? stripTrailingNewlines(editedLf) : editedLf
+  const reconciledTrailingNewlines = stripEnd
+    ? editedTrailingNewlines + originalTrailingNewlines
+    : ''
   // Why: dmp's half-match accelerator ignores the diff deadline (100ms+ on repeated seeds), so bail to canonical for highly repetitive replacements.
   if (hasRepeatedHalfMatchSeed(baseBody, editedBody)) {
-    return restoreEol(editedLf, eol)
+    return canonicalFallback()
   }
   let diffs = makeDiff(baseBody, editedBody, {
     checkLines: true,
@@ -115,13 +123,13 @@ export function reconcileSerializedMarkdown({
 
   // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match, fall back to canonical.
   if (results.some((applied) => !applied)) {
-    return restoreEol(editedLf, eol)
+    return canonicalFallback()
   }
 
   // Branch 6: prove reconciled bytes render-equal the editor's document — any fuzzy misplacement changes canonical output and is caught here → canonical fallback.
   const reparsed = roundTrip(reconciledLf)
   if (reparsed === null || normalizeForSafety(reparsed) !== normalizeForSafety(editedLf)) {
-    return restoreEol(editedLf, eol)
+    return canonicalFallback()
   }
 
   // Restore the detected EOL as the final step so reconciled CRLF stays CRLF.

--- a/src/renderer/src/components/editor/tiptap-marked-facade.ts
+++ b/src/renderer/src/components/editor/tiptap-marked-facade.ts
@@ -13,6 +13,17 @@ import {
   marked
 } from 'marked'
 
+/** Rewrites escape tokens in place (marked fills caller-owned arrays for table cells). */
+function preserveEscapedCharacters(tokens: Token[]): Token[] {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    if (token.type === 'escape') {
+      tokens[index] = { type: 'text', raw: token.raw, text: token.text, escaped: false }
+    }
+  }
+  return tokens
+}
+
 export function createTiptapMarkedFacade(): typeof marked {
   const registry = new Marked()
 
@@ -25,6 +36,12 @@ export function createTiptapMarkedFacade(): typeof marked {
         ...options,
         extensions: registry.defaults.extensions
       })
+    }
+
+    // Why: Tiptap's markdown parser has no case for marked's `escape` token, so
+    // `\$`, `\*`, `\_`, `\[` would be deleted from the document on load.
+    inlineTokens(src: string, tokens: Token[] = []): Token[] {
+      return preserveEscapedCharacters(super.inlineTokens(src, tokens))
     }
   }
 

--- a/src/renderer/src/components/editor/tiptap-marked-facade.ts
+++ b/src/renderer/src/components/editor/tiptap-marked-facade.ts
@@ -13,17 +13,6 @@ import {
   marked
 } from 'marked'
 
-/** Rewrites escape tokens in place (marked fills caller-owned arrays for table cells). */
-function preserveEscapedCharacters(tokens: Token[]): Token[] {
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index]
-    if (token.type === 'escape') {
-      tokens[index] = { type: 'text', raw: token.raw, text: token.text, escaped: false }
-    }
-  }
-  return tokens
-}
-
 export function createTiptapMarkedFacade(): typeof marked {
   const registry = new Marked()
 
@@ -36,12 +25,6 @@ export function createTiptapMarkedFacade(): typeof marked {
         ...options,
         extensions: registry.defaults.extensions
       })
-    }
-
-    // Why: Tiptap's markdown parser has no case for marked's `escape` token, so
-    // `\$`, `\*`, `\_`, `\[` would be deleted from the document on load.
-    inlineTokens(src: string, tokens: Token[] = []): Token[] {
-      return preserveEscapedCharacters(super.inlineTokens(src, tokens))
     }
   }
 


### PR DESCRIPTION
## ELI5

Open a markdown file full of dollar amounts in Orca's rich editor and it gets reformatted on the spot: escaped characters vanish, money turns into math equations, and the first save rewrites the whole file. This PR makes the editor read those files faithfully and write back only what you changed.

## What Changed

- `rich-markdown-escaped-character.ts` (new): a non-inclusive mark that owns marked's escape rule. `\X` parses to the character `X` carrying the mark, and the serializer-fidelity pass writes marked text back as `\X` per character, so escapes round-trip byte for byte inside table cells, links, emphasis, and list items. Inside a code mark the character is emitted bare; `& < >` are left to the serializer's entity encoding. A plain text node cannot do this (Tiptap 3.22.5's text serializer has no re-escape hook), an atom node cannot either (the serializer closes every active mark before a non-text node, so `**cost \$5 total**` split into `**cost **\$**5 total**`), and a mark's own `renderMarkdown` is one prefix for the whole run (`\*\*` would collapse to `\**`), hence the wrapper.
- `rich-markdown-serializer-fidelity.ts` (new): wraps `getMarkdown` and rewrites the document JSON into its source form before Tiptap serializes it. Besides the escaped-character expansion it re-escapes `|` in table cell text (marked unescapes `\|` per cell before inline lexing, so a bare `|` split the row on the next load), escapes `(` and `)` in link and image destinations (`[a](b\)c)` came back as `[a](b)c)`), `[ ] \` in image alt text, and `"` in titles.
- `rich-markdown-extensions.ts`: `BlockMath` gets a `start` that only fires at a line start. marked ends a paragraph wherever a block tokenizer's `start` points, and upstream used `indexOf('$$')`, so `costs $$ big` split the paragraph.
- `rich-markdown-extensions.ts`: `InlineMath` gets a Pandoc-style tokenizer. Both `$` must touch the formula, the closing `$` must not be followed by a digit, and an escaped `\$` never closes a formula (`costs $5 to \$x` stays text). `$E = mc^2$`, `$x_1$`, a formula wrapped across a soft line break, and a trailing `\\` still parse; `$10 to $20`, `at $0`, `$x$2`, `$ x$`, `$x $` stay text. Known hole, same as Pandoc: `price $5-$x` still parses as math.
- `rich-markdown-source-reconcile.ts`: when the source ends in exactly one newline that canonical lacks, branch 4 first patches the newline-stripped bodies and re-attaches the run; if that fails the branch-5/6 proof (a whitespace-only last line, for instance), it retries the whole-text patch that ran before, so no file does worse than before and the extra round trip only runs on that failure. A source ending in a blank line parses to a trailing empty paragraph, so canonical ends in `\n\n` too and goes straight to the whole-text patch. Canonical fallbacks now keep the source's single trailing newline instead of dropping it.

## Why

Open a markdown file with dollar amounts (a finance doc, invoices, tax notes) in the rich editor and it is reformatted on load; the first save then rewrites the entire file.

1. **Backslash escapes are deleted on load.** marked emits an `escape` inline token for `\$`, `\*`, `\_`, `\[`, and `@tiptap/markdown` 3.22.5 has no case for it, so the character is gone from the document the moment the file opens. `cost was \$1,200` displays and saves as `cost was 1,200`.
2. **Money renders as math.** The `@tiptap/extension-mathematics` tokenizer treats any same-line `$…$` pair as LaTeX. `(deficit −$509,542 by end-2020), so stock basis entered 2021 at $0` becomes one KaTeX atom, and because the latex is trimmed it serializes back as `at$0`.
3. **Any edit at the end of the file rewrites the whole file.** In `reconcileSerializedMarkdown`, `getMarkdown()` emits no trailing newline for a source that ends in a single newline, while the on-disk source normally has one. For an end-of-document hunk the diff-match-patch context is end-of-text padding, so the patch lands one character late, the branch-6 round-trip proof fails, and the code falls back to canonical output for the entire document: every `\$`, every `&` → `&amp;`, every table re-padded. Middle-of-document edits were fine. Reproduces on a 57-character file.

## Linked Issue

Fixes #20425

## Visual Proof

Same fixture file opened in the rich editor, captured headless through the e2e harness (`ORCA_BACKGROUND_LAUNCH=1`, Playwright CDP) against the base commit 403b62a8d8 and against this branch.

| Before (403b62a8d8) | After (this branch) |
|---|---|
| ![pr20406-before-rich-editor.png](https://github.com/user-attachments/assets/19543003-dc9c-4736-973b-47078ed9f443) | ![pr20406-after-rich-editor.png](https://github.com/user-attachments/assets/2f521f06-83b2-4368-acfa-ba2bbb1e48ec) |

Before: the `$509,542 … at $0` span renders as italic KaTeX, every `\$` is gone (`cost was 1,200`, `Total: 1,235`, `Distribution 500`). After: the file reads as written.

The same run then typed ` Added.` at the end of the document and saved. What reached disk:

<details>
<summary>Fixture as opened</summary>

```markdown
# Shareholder basis

(deficit −$509,542 by end-2020), so stock basis entered 2021 at $0.

Escaped: cost was \$1,200 and the fee was \$35 per filing. **Total: \$1,235** due.

R&D credits for Nell & Mary, 2018 & 2020.

| Item         | Amount |
|--------------|-------:|
| Basis        | $1,000 |
| Distribution | \$500  |

Trailing paragraph.
```
</details>

<details>
<summary>Before: whole file rewritten on save</summary>

```markdown
# Shareholder basis

(deficit −$509,542 by end-2020), so stock basis entered 2021 at$0.

Escaped: cost was 1,200 and the fee was 35 per filing. **Total: 1,235** due.

R&amp;D credits for Nell &amp; Mary, 2018 &amp; 2020.


| Item         | Amount |
| ------------ | ------: |
| Basis        | $1,000 |
| Distribution | 500    |


Trailing paragraph. Added.
```
</details>

<details>
<summary>After: only the edit changed</summary>

```markdown
# Shareholder basis

(deficit −$509,542 by end-2020), so stock basis entered 2021 at $0.

Escaped: cost was \$1,200 and the fee was \$35 per filing. **Total: \$1,235** due.

R&D credits for Nell & Mary, 2018 & 2020.

| Item         | Amount |
|--------------|-------:|
| Basis        | $1,000 |
| Distribution | \$500  |

Trailing paragraph. Added.
```
</details>

## Testing

- `markdown-round-trip.test.ts`: a battery of escapes (`\$ \# 1\. \- \*\* \_ \` \~ \\`), including escapes inside bold, links, emphasis, and consecutive escapes inside bold, round-trips byte for byte and is stable on a second round trip; escapes under a code mark serialize bare and `\&`/`\<` fall back to entity encoding; `\|` in table cells (code spans included), `\)` in destinations, `\]` in alt text, and `\"` in titles round-trip; a mid-line `$$` no longer splits a paragraph while a `$$` block still parses; escaped dollars survive in table cells and never become math; dollar amounts and the Pandoc-rejected shapes produce zero inline-math nodes; real inline math, wrapped math, and a trailing LaTeX line break still parse.
- `rich-markdown-source-reconcile.test.ts`: end-of-file edits with a trailing-newline source (LF and CRLF), a source without a trailing newline, a real-serializer case with `\$`, `&` and a padded table that must keep its source bytes, typing into and deleting a trailing empty paragraph and appending after a whitespace-only last line (the shapes the first commits regressed), and a canonical fallback keeping the trailing newline.

`pnpm tc`, the full `src/renderer/src/components/editor` suite (1445 tests), `check:code-quality:changed`, `check:max-lines-ratchet`, and `check:reliability-gates` pass.

Tested on macOS. The change is renderer-side markdown parsing and serialization with no platform-specific code path; SSH and folder workspaces run the same renderer code, and nothing on the wire changes.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude (Claude Code): investigation, fix, tests, and two adversarial three-agent review rounds whose findings were each reproduced with the real serializer before being acted on. Directed and reviewed by the author.

## Review

AI code review summary (Claude Code, two adversarial three-reviewer rounds plus a final pass on the head commit):

- **Cross-platform (macOS / Linux / Windows):** pure TypeScript in the renderer, no path or shell code. CRLF sources are covered by the reconcile tests (end-of-file edit, whitespace-only last line). No platform-specific risk found.
- **SSH / remote / local:** the reconcile and serializer run in the renderer for local and remote files alike. No RPC params, stream frames, or published content change, so mixed client/host versions are unaffected. A whole-file canonical rewrite over SSH was the pre-existing cost this PR removes.
- **Agents and integrations:** the rich editor extension set is shared by the live editor, rich-mode eligibility, and the reconcile serializer, and all three still build from `createRichMarkdownExtensions`, so detection and serialization cannot drift. The GitHub and Linear markdown composers use their own extension sets and are untouched. The markdown preview (`remark-math`) is unchanged and still renders `$10 to $20` as math; that mismatch with the editor is noted below.
- **Performance:** the inline-math regex has no ambiguous alternation and measured within noise of upstream on 20 KB lines and 5,000 dollar pairs; the block-math start pattern is a single scan per paragraph; the extra reconcile round trip runs only when the first patch attempt fails its proof. marked's pre-existing quadratic scan on underscore-heavy 100 KB paragraphs is unchanged.
- **UI quality:** escaped characters render as ordinary text (a non-inclusive mark on a plain `<span>`), so cursor movement, Backspace, selection, copy, and find/replace behave as for any text. Money no longer renders as a KaTeX atom.
- **Security:** no new inputs cross a trust boundary. The serializer pre-pass rewrites document JSON already in memory; the escape mark's `parseHTML` accepts only its own marker span and carries no attribute payload.
- **Review findings acted on:** round one found the escape fix was parse-side only, the body-strip reconcile regressed blank-line-terminated files, and the math regex broke wrapped formulas; round two found an escape atom split any mark spanning it and disabled find/replace near it, a whitespace-only last line still fell to canonical, and an escaped `\$` could close a formula. Each is fixed in a later commit with a regression test.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Backwards compatibility: files that never held escapes, money-shaped `$` pairs, or end-of-file edits serialize exactly as before; the reconcile keeps the previous whole-text patch as its second attempt so no file does worse than before.
- Behaviour change worth a changelog line: `$ x $` with spaces inside the delimiters is now text, per Pandoc's rule; upstream rendered it as math.
- Out of scope, pre-existing on the base branch and unchanged here:
  - `&` → `&amp;` and table re-padding are still what the canonical serializer emits; the reconcile fix keeps them out of untouched regions, but a real edit inside such a line still canonicalizes that line.
  - Pre-existing on the base branch and unchanged here: a `\`+newline hard break is re-emitted as two spaces plus newline (same meaning); `\[ \]` inside link text comes back as bare balanced brackets (same meaning); marked's inline text scan is quadratic on underscore-heavy paragraphs (about 7 s at 100 KB, inside marked itself); an angle-bracket destination `[a](<b c>)` is treated as inline HTML by Orca's raw-HTML pass.
  - Upstream `@tiptap/markdown` 3.31.3 also fixes the escape drop. This PR does not bump TipTap.
  - The markdown preview's `remark-math` single-dollar handling is unchanged, so preview and editor disagree on `$10 to $20`.

## Author

Elon musk is a nazi and I don’t use nazi software

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)




